### PR TITLE
fix:orb squeeze provides incorrect shape for energy tensor

### DIFF
--- a/torch_sim/models/orb.py
+++ b/torch_sim/models/orb.py
@@ -416,7 +416,7 @@ class OrbModel(ModelInterface):
             if not model_has_direct_heads and prop == "stress":
                 continue
             _property = "energy" if prop == "free_energy" else prop
-            results[prop] = predictions[_property].squeeze()
+            results[prop] = predictions[_property]
 
         if self.conservative:
             results["forces"] = results[self.model.grad_forces_name]


### PR DESCRIPTION
## Summary

OrbModel wrapper returns a dim-0 tensor for energy for a input containing a single system, because of a squeeze() in orb.py line 419. This is not the behaviour of other models like SevenNet. This causes ts.integrate to fail when trying to split the system.

```
from ase.build import bulk
from torch_sim.models.orb import OrbModel
from torch_sim.state import initialize_state
from orb_models.forcefield import pretrained
import torch
import os
import torch_sim as ts
device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
orbff = pretrained.orb_v3_conservative_inf_omat(
    device=device,
    precision="float32-highest",
    compile=False
)
orb_model = OrbModel(model=orbff, dtype=torch.get_default_dtype())

from torch_sim.integrators.nvt import nvt_langevin

n_steps = 30
timestep = 0.001
temperature = 300.0  # K
filename = "nvt_trajectory.h5"
save_dir = "notebook/results2"

filename = os.path.join(save_dir, filename)
reporter = ts.TrajectoryReporter(
    filenames=[filename],
    state_frequency=10,
)

system = bulk('Ti')
system = initialize_state(system, device=device, dtype=torch.get_default_dtype())
print(orb_model(system)["energy"]) # tensor(-15.5739, device='cuda:0', grad_fn=<SqueezeBackward0>)

# Run NVT simulation
_ = ts.integrate(
    system,
    orb_model,
    # sevennet_model,
    integrator=nvt_langevin,
    n_steps=n_steps,
    timestep=timestep,
    temperature=temperature,
    trajectory_reporter=reporter,
)
## RuntimeError: split expects at least a 1-dimensional tensor
```

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
