### PR TITLE
Feature/batched nvt nose hoover

### DIFF
--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -8,6 +8,8 @@ from torch_sim.integrators import (
     npt_langevin,
     nve,
     nvt_langevin,
+    nvt_nose_hoover,
+    nvt_nose_hoover_invariant,
 )
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.quantities import calc_kT
@@ -299,6 +301,181 @@ def test_nvt_langevin_multi_kt(
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
+
+
+def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
+    dtype = torch.float64
+    n_steps = 100
+    dt = torch.tensor(0.001, dtype=dtype)
+    kT = torch.tensor(300, dtype=dtype) * MetalUnits.temperature
+
+    # Initialize integrator
+    init_fn, update_fn = nvt_nose_hoover(
+        model=lj_model,
+        dt=dt,
+        kT=kT,
+    )
+
+    # Run dynamics for several steps
+    state = init_fn(state=ar_double_sim_state, seed=42)
+    energies = []
+    temperatures = []
+    invariants = []
+    for _step in range(n_steps):
+        state = update_fn(state=state)
+
+        # Calculate instantaneous temperature from kinetic energy
+        temp = calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        )
+        energies.append(state.energy)
+        temperatures.append(temp / MetalUnits.temperature)
+        invariants.append(nvt_nose_hoover_invariant(state, kT))
+
+    # Convert temperatures list to tensor
+    temperatures_tensor = torch.stack(temperatures)
+    temperatures_list = [t.tolist() for t in temperatures_tensor.T]
+
+    energies_tensor = torch.stack(energies)
+    energies_list = [t.tolist() for t in energies_tensor.T]
+
+    invariants_tensor = torch.stack(invariants)
+
+    # Basic sanity checks
+    assert len(energies_list[0]) == n_steps
+    assert len(temperatures_list[0]) == n_steps
+
+    # Check temperature is roughly maintained for each trajectory
+    mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
+    for mean_temp in mean_temps:
+        assert (
+            abs(mean_temp - kT.item() / MetalUnits.temperature) < 100.0
+        )  # Allow for thermal fluctuations
+
+    # Check energy is stable for each trajectory
+    for traj in energies_list:
+        energy_std = torch.tensor(traj).std()
+        assert energy_std < 1.0  # Adjust threshold as needed
+
+    # Check invariant conservation (should be roughly constant)
+    for traj_idx in range(invariants_tensor.shape[1]):
+        invariant_traj = invariants_tensor[:, traj_idx]
+        invariant_std = invariant_traj.std()
+        # Allow for some drift but should be relatively stable
+        # Less than 10% relative variation
+        assert invariant_std / invariant_traj.mean() < 0.1
+
+    # Check positions and momenta have correct shapes
+    n_atoms = 8
+
+    # Verify the two systems remain distinct
+    pos_diff = torch.norm(
+        state.positions[:n_atoms].mean(0) - state.positions[n_atoms:].mean(0)
+    )
+    assert pos_diff > 0.0001  # Systems should remain separated
+
+
+def test_nvt_nose_hoover_multi_equivalent_to_single(
+    mixed_double_sim_state: ts.SimState, lj_model: LennardJonesModel
+):
+    """Test that nvt_nose_hoover with multiple identical kT values behaves like
+    running different single kT, assuming same initial state
+    (most importantly same momenta)."""
+    dtype = torch.float64
+    n_steps = 100
+    dt = torch.tensor(0.001, dtype=dtype)
+    kT = torch.tensor(300, dtype=dtype) * MetalUnits.temperature
+
+    # Initialize integrator
+    init_fn, update_fn = nvt_nose_hoover(
+        model=lj_model,
+        dt=dt,
+        kT=kT,
+    )
+    final_temperatures = []
+    initial_momenta = []
+    # Run dynamics for several steps
+    for i in range(mixed_double_sim_state.n_systems):
+        state = init_fn(state=mixed_double_sim_state[i], seed=42)
+        initial_momenta.append(state.momenta.clone())
+        for _step in range(n_steps):
+            state = update_fn(state=state)
+
+            # Calculate instantaneous temperature from kinetic energy
+        temp = calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        )
+        final_temperatures.append(temp / MetalUnits.temperature)
+
+    initial_momenta_tensor = torch.concat(initial_momenta)
+    final_temperatures = torch.concat(final_temperatures)
+    state = init_fn(state=mixed_double_sim_state, seed=42, momenta=initial_momenta_tensor)
+    for _step in range(n_steps):
+        state = update_fn(state=state)
+
+        # Calculate instantaneous temperature from kinetic energy
+    temp = calc_kT(
+        masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+    )
+
+    assert torch.allclose(final_temperatures, temp / MetalUnits.temperature)
+
+
+def test_nvt_nose_hoover_multi_kt(
+    ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel
+):
+    dtype = torch.float64
+    n_steps = 200
+    dt = torch.tensor(0.001, dtype=dtype)
+    kT = torch.tensor([300, 10_000], dtype=dtype) * MetalUnits.temperature
+
+    # Initialize integrator
+    init_fn, update_fn = nvt_nose_hoover(
+        model=lj_model,
+        dt=dt,
+        kT=kT,
+    )
+
+    # Run dynamics for several steps
+    state = init_fn(state=ar_double_sim_state, seed=42)
+    energies = []
+    temperatures = []
+    invariants = []
+    for _step in range(n_steps):
+        state = update_fn(state=state)
+
+        # Calculate instantaneous temperature from kinetic energy
+        temp = calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        )
+        energies.append(state.energy)
+        temperatures.append(temp / MetalUnits.temperature)
+        invariants.append(nvt_nose_hoover_invariant(state, kT))
+
+    # Convert temperatures list to tensor
+    temperatures_tensor = torch.stack(temperatures)
+    temperatures_list = [t.tolist() for t in temperatures_tensor.T]
+
+    energies_tensor = torch.stack(energies)
+    energies_list = [t.tolist() for t in energies_tensor.T]
+
+    invariants_tensor = torch.stack(invariants)
+
+    # Basic sanity checks
+    assert len(energies_list[0]) == n_steps
+    assert len(temperatures_list[0]) == n_steps
+
+    # Check temperature is roughly maintained for each trajectory
+    mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
+    assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
+
+    # Check invariant conservation for each system
+    for traj_idx in range(invariants_tensor.shape[1]):
+        invariant_traj = invariants_tensor[:, traj_idx]
+        invariant_std = invariant_traj.std()
+        # Allow for some drift but should be relatively stable
+        # Less than 10% relative variation
+        assert invariant_std / invariant_traj.mean() < 0.1
 
 
 def test_nve(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):

--- a/torch_sim/integrators/__init__.py
+++ b/torch_sim/integrators/__init__.py
@@ -24,4 +24,4 @@ Notes:
 from .md import MDState, calculate_momenta, momentum_step, position_step, velocity_verlet
 from .npt import NPTLangevinState, npt_langevin
 from .nve import nve
-from .nvt import nvt_langevin
+from .nvt import nvt_langevin, nvt_nose_hoover, nvt_nose_hoover_invariant

--- a/torch_sim/integrators/md.py
+++ b/torch_sim/integrators/md.py
@@ -208,13 +208,13 @@ class NoseHooverChain:
     in the chain has its own positions, momenta, and masses.
 
     Attributes:
-        positions: Positions of the chain thermostats. Shape: [chain_length]
-        momenta: Momenta of the chain thermostats. Shape: [chain_length]
-        masses: Masses of the chain thermostats. Shape: [chain_length]
+        positions: Positions of the chain thermostats. Shape: [n_systems, chain_length]
+        momenta: Momenta of the chain thermostats. Shape: [n_systems, chain_length]
+        masses: Masses of the chain thermostats. Shape: [n_systems, chain_length]
         tau: Thermostat relaxation time. Longer values give better stability
-            but worse temperature control. Shape: scalar
-        kinetic_energy: Current kinetic energy of the coupled system. Shape: scalar
-        degrees_of_freedom: Number of degrees of freedom in the coupled system
+            but worse temperature control. Shape: [n_systems] or scalar
+        kinetic_energy: Current kinetic energy of the coupled system. Shape: [n_systems]
+        degrees_of_freedom: Number of degrees of freedom per system. Shape: [n_systems]
     """
 
     positions: torch.Tensor
@@ -222,7 +222,8 @@ class NoseHooverChain:
     masses: torch.Tensor
     tau: torch.Tensor
     kinetic_energy: torch.Tensor
-    degrees_of_freedom: int
+    degrees_of_freedom: torch.Tensor
+    system_idx: torch.Tensor | None = None
 
 
 @dataclass
@@ -267,7 +268,7 @@ SUZUKI_YOSHIDA_WEIGHTS = {
 }
 
 
-def construct_nose_hoover_chain(
+def construct_nose_hoover_chain(  # noqa: C901 PLR0915
     dt: torch.Tensor,
     chain_length: int,
     chain_steps: int,
@@ -306,14 +307,14 @@ def construct_nose_hoover_chain(
     """
 
     def init_fn(
-        degrees_of_freedom: int, KE: torch.Tensor, kT: torch.Tensor
+        degrees_of_freedom: torch.Tensor, KE: torch.Tensor, kT: torch.Tensor
     ) -> NoseHooverChain:
         """Initialize a Nose-Hoover chain state.
 
         Args:
-            degrees_of_freedom: Number of degrees of freedom in coupled system
-            KE: Initial kinetic energy of the system
-            kT: Target temperature in energy units
+            degrees_of_freedom: Number of degrees of freedom per system, shape [n_systems]
+            KE: Initial kinetic energy per system, shape [n_systems]
+            kT: Target temperature in energy units, shape [n_systems] or scalar
 
         Returns:
             Initial NoseHooverChain state
@@ -321,16 +322,40 @@ def construct_nose_hoover_chain(
         device = KE.device
         dtype = KE.dtype
 
-        xi = torch.zeros(chain_length, dtype=dtype, device=device)
-        p_xi = torch.zeros(chain_length, dtype=dtype, device=device)
+        # Ensure n_systems is determined from KE shape
+        n_systems = KE.shape[0] if KE.dim() > 0 else 1
 
-        Q = kT * tau**2 * torch.ones(chain_length, dtype=dtype, device=device)
-        Q[0] *= degrees_of_freedom
+        # Initialize chain variables with proper batch dimensions
+        xi = torch.zeros((n_systems, chain_length), dtype=dtype, device=device)
+        p_xi = torch.zeros((n_systems, chain_length), dtype=dtype, device=device)
 
-        return NoseHooverChain(xi, p_xi, Q, tau, KE, degrees_of_freedom)
+        # Broadcast tau to match n_systems
+        if isinstance(tau, torch.Tensor):
+            tau_batched = tau.expand(n_systems) if tau.dim() == 0 else tau
+        else:
+            tau_batched = torch.full((n_systems,), tau, dtype=dtype, device=device)
+
+        # Ensure kT has proper batch dimension
+        if isinstance(kT, torch.Tensor):
+            kT_batched = kT.expand(n_systems) if kT.dim() == 0 else kT
+        else:
+            kT_batched = torch.full((n_systems,), kT, dtype=dtype, device=device)
+
+        Q = (
+            kT_batched.unsqueeze(-1)
+            * tau_batched.unsqueeze(-1) ** 2
+            * torch.ones((n_systems, chain_length), dtype=dtype, device=device)
+        )
+        Q[:, 0] *= degrees_of_freedom
+
+        return NoseHooverChain(xi, p_xi, Q, tau_batched, KE, degrees_of_freedom)
 
     def substep_fn(
-        delta: torch.Tensor, P: torch.Tensor, state: NoseHooverChain, kT: torch.Tensor
+        delta: torch.Tensor,
+        P: torch.Tensor,
+        state: NoseHooverChain,
+        kT: torch.Tensor,
+        system_idx: torch.Tensor,
     ) -> tuple[torch.Tensor, NoseHooverChain, torch.Tensor]:
         """Perform single update of chain parameters and rescale velocities.
 
@@ -339,6 +364,7 @@ def construct_nose_hoover_chain(
             P: System momenta to be rescaled
             state: Current chain state
             kT: Target temperature
+            system_idx: Index of the system being evolved
 
         Returns:
             Tuple of (rescaled momenta, updated chain state, temperature)
@@ -358,40 +384,52 @@ def construct_nose_hoover_chain(
 
         M = chain_length - 1
 
+        # Ensure kT has proper batch dimension
+        if isinstance(kT, torch.Tensor):
+            kT_batched = kT.expand(KE.shape[0]) if kT.dim() == 0 else kT
+        else:
+            kT_batched = torch.full_like(KE, kT)
+
         # Update chain momenta backwards
-        G = p_xi[M - 1] ** 2 / Q[M - 1] - kT
-        p_xi[M] += delta_4 * G
+        G = p_xi[:, M - 1] ** 2 / Q[:, M - 1] - kT_batched
+        p_xi[:, M] += delta_4 * G
 
         for m in range(M - 1, 0, -1):
-            G = p_xi[m - 1] ** 2 / Q[m - 1] - kT
-            scale = torch.exp(-delta_8 * p_xi[m + 1] / Q[m + 1])
-            p_xi[m] = scale * (scale * p_xi[m] + delta_4 * G)
+            G = p_xi[:, m - 1] ** 2 / Q[:, m - 1] - kT_batched
+            scale = torch.exp(-delta_8 * p_xi[:, m + 1] / Q[:, m + 1])
+            p_xi[:, m] = scale * (scale * p_xi[:, m] + delta_4 * G)
 
         # Update system coupling
-        G = 2.0 * KE - DOF * kT
-        scale = torch.exp(-delta_8 * p_xi[1] / Q[1])
-        p_xi[0] = scale * (scale * p_xi[0] + delta_4 * G)
+        G = 2.0 * KE - DOF * kT_batched
+        scale = torch.exp(-delta_8 * p_xi[:, 1] / Q[:, 1])
+        p_xi[:, 0] = scale * (scale * p_xi[:, 0] + delta_4 * G)
 
         # Rescale system momenta
-        scale = torch.exp(-delta_2 * p_xi[0] / Q[0])
+        scale = torch.exp(-delta_2 * p_xi[:, 0] / Q[:, 0])
         KE = KE * scale**2
-        P = P * scale
+
+        # Apply scale to momenta - need to map from system to atom indices
+        atom_scale = scale[system_idx].unsqueeze(-1)
+        P = P * atom_scale
 
         # Update positions
         xi = xi + delta_2 * p_xi / Q
 
         # Update chain momenta forwards
-        G = 2.0 * KE - DOF * kT
+        G = 2.0 * KE - DOF * kT_batched
         for m in range(M):
-            scale = torch.exp(-delta_8 * p_xi[m + 1] / Q[m + 1])
-            p_xi[m] = scale * (scale * p_xi[m] + delta_4 * G)
-            G = p_xi[m] ** 2 / Q[m] - kT
-        p_xi[M] += delta_4 * G
+            scale = torch.exp(-delta_8 * p_xi[:, m + 1] / Q[:, m + 1])
+            p_xi[:, m] = scale * (scale * p_xi[:, m] + delta_4 * G)
+            G = p_xi[:, m] ** 2 / Q[:, m] - kT_batched
+        p_xi[:, M] += delta_4 * G
 
-        return P, NoseHooverChain(xi, p_xi, Q, _tau, KE, DOF), kT
+        return P, NoseHooverChain(xi, p_xi, Q, _tau, KE, DOF), kT_batched
 
     def half_step_chain_fn(
-        P: torch.Tensor, state: NoseHooverChain, kT: torch.Tensor
+        P: torch.Tensor,
+        state: NoseHooverChain,
+        kT: torch.Tensor,
+        system_idx: torch.Tensor,
     ) -> tuple[torch.Tensor, NoseHooverChain]:
         """Evolve chain for half timestep using multi-timestep integration.
 
@@ -399,12 +437,13 @@ def construct_nose_hoover_chain(
             P: System momenta to be rescaled
             state: Current chain state
             kT: Target temperature
+            system_idx: Index of the system being evolved
 
         Returns:
             Tuple of (rescaled momenta, updated chain state)
         """
         if chain_steps == 1 and sy_steps == 1:
-            P, state, _ = substep_fn(dt, P, state, kT)
+            P, state, _ = substep_fn(dt, P, state, kT, system_idx)
             return P, state
 
         delta = dt / chain_steps
@@ -412,7 +451,7 @@ def construct_nose_hoover_chain(
 
         for step in range(chain_steps * sy_steps):
             d = delta * weights[step % sy_steps]
-            P, state, _ = substep_fn(d, P, state, kT)
+            P, state, _ = substep_fn(d, P, state, kT, system_idx)
 
         return P, state
 
@@ -429,8 +468,21 @@ def construct_nose_hoover_chain(
         device = state.positions.device
         dtype = state.positions.dtype
 
-        Q = kT * state.tau**2 * torch.ones(chain_length, dtype=dtype, device=device)
-        Q[0] *= state.degrees_of_freedom
+        # Get number of systems
+        n_systems = state.kinetic_energy.shape[0]
+
+        # Ensure kT has proper batch dimension
+        if isinstance(kT, torch.Tensor):
+            kT_batched = kT.expand(n_systems) if kT.dim() == 0 else kT
+        else:
+            kT_batched = torch.full((n_systems,), kT, dtype=dtype, device=device)
+
+        Q = (
+            kT_batched.unsqueeze(-1)
+            * state.tau.unsqueeze(-1) ** 2
+            * torch.ones((n_systems, chain_length), dtype=dtype, device=device)
+        )
+        Q[:, 0] *= state.degrees_of_freedom
 
         return NoseHooverChain(
             state.positions,

--- a/torch_sim/integrators/nvt.py
+++ b/torch_sim/integrators/nvt.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import torch
 
-from torch_sim.integrators.md import (
+from torch_sim.integrators.md_batched import (
     MDState,
     NoseHooverChain,
     NoseHooverChainFns,
@@ -377,14 +377,14 @@ def nvt_nose_hoover(
         )
 
         # Calculate degrees of freedom per system
-        n_atoms_per_system = torch.bincount(state.system_idx)
+        n_atoms_per_system = state.n_atoms_per_system
         dof_per_system = (
             n_atoms_per_system * state.positions.shape[-1]
         )  # n_atoms * n_dimensions
 
         # For now, sum the per-system DOF as chain expects a single int
         # This is a limitation that should be addressed in the chain implementation
-        total_dof = int(dof_per_system.sum().item())
+        # total_dof = int(dof_per_system.sum().item())
 
         # Initialize state
         state = NVTNoseHooverState(
@@ -397,7 +397,7 @@ def nvt_nose_hoover(
             pbc=state.pbc,
             atomic_numbers=atomic_numbers,
             system_idx=state.system_idx,
-            chain=chain_fns.initialize(total_dof, KE, kT),
+            chain=chain_fns.initialize(dof_per_system, KE, kT),
             _chain_fns=chain_fns,  # Store the chain functions
         )
         return state  # noqa: RET504
@@ -430,10 +430,10 @@ def nvt_nose_hoover(
         chain = state.chain
 
         # Update chain masses based on target temperature
-        chain = chain_fns.update_mass(chain, kT)
+        # chain = chain_fns.update_mass(chain, kT)
 
         # First half-step of chain evolution
-        momenta, chain = chain_fns.half_step(state.momenta, chain, kT)
+        momenta, chain = chain_fns.half_step(state.momenta, chain, kT, state.system_idx)
         state.momenta = momenta
 
         # Full velocity Verlet step
@@ -446,7 +446,7 @@ def nvt_nose_hoover(
         chain.kinetic_energy = KE
 
         # Second half-step of chain evolution
-        momenta, chain = chain_fns.half_step(state.momenta, chain, kT)
+        momenta, chain = chain_fns.half_step(state.momenta, chain, kT, state.system_idx)
         state.momenta = momenta
         state.chain = chain
 
@@ -500,8 +500,8 @@ def nvt_nose_hoover_invariant(
     # Add first thermostat term
     c = state.chain
     # Ensure chain momenta and masses broadcast correctly with batch dimensions
-    chain_ke_0 = c.momenta[0] ** 2 / (2 * c.masses[0])
-    chain_pe_0 = dof * kT * c.positions[0]
+    chain_ke_0 = c.momenta[:, 0] ** 2 / (2 * c.masses[:, 0])
+    chain_pe_0 = dof * kT * c.positions[:, 0]
 
     # If chain variables are scalars but we have batches, broadcast them
     if chain_ke_0.numel() == 1 and e_tot.numel() > 1:
@@ -512,9 +512,11 @@ def nvt_nose_hoover_invariant(
     e_tot = e_tot + chain_ke_0 + chain_pe_0
 
     # Add remaining chain terms
-    for pos, momentum, mass in zip(
-        c.positions[1:], c.momenta[1:], c.masses[1:], strict=True
-    ):
+    for i in range(1, c.positions.shape[1]):
+        pos = c.positions[:, i]
+        momentum = c.momenta[:, i]
+        mass = c.masses[:, i]
+
         chain_ke = momentum**2 / (2 * mass)
         chain_pe = kT * pos
 

--- a/torch_sim/models/orb.py
+++ b/torch_sim/models/orb.py
@@ -416,7 +416,7 @@ class OrbModel(ModelInterface):
             if not model_has_direct_heads and prop == "stress":
                 continue
             _property = "energy" if prop == "free_energy" else prop
-            results[prop] = predictions[_property].squeeze()
+            results[prop] = predictions[_property]
 
         if self.conservative:
             results["forces"] = results[self.model.grad_forces_name]


### PR DESCRIPTION
## Summary

Add support for batch systems for NVT Nosé Hoover #262 
Add tests: batched systems, identical results for batched systems and independent single run (with same initial state, most importantly the momenta).

I've also carefully checked that the behaviour is the same as the previous non batched implementation.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [X] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [X] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
