### PR TITLE
Remove Contributor License Agreement (CLA) in favor of certification in contributing.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,4 @@ Before a pull request can be merged, the following items must be checked:
 * [ ] Tests have been added for any new functionality or bug fixes.
 * [ ] I have read and agree to the Contributor's Certification in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-
 We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,5 +10,7 @@ Before a pull request can be merged, the following items must be checked:
 * [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
 * [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
 * [ ] Tests have been added for any new functionality or bug fixes.
+* [ ] I have read and agree to the Contributor's Certification in [CONTRIBUTING.md](CONTRIBUTING.md).
+
 
 We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,8 +1,0 @@
-# Configuration for the DCO Probot
-# See https://github.com/probot/dco#configuration for more options
-
-# Message to display on a pull request with a failing DCO check
-failureMessage: "All commits in this PR must be signed off."
-
-# Message to display on a pull request with a passing DCO check
-successMessage: "All commits have been signed off. DCO check passed!"

--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,8 @@
+# Configuration for the DCO Probot
+# See https://github.com/probot/dco#configuration for more options
+
+# Message to display on a pull request with a failing DCO check
+failureMessage: "All commits in this PR must be signed off."
+
+# Message to display on a pull request with a passing DCO check
+successMessage: "All commits have been signed off. DCO check passed!"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,61 @@
 # Contributing to TorchSim
 
-TorchSim is an experimental library and we would appreciate any feedback from the community.
+TorchSim welcomes contributions and feedback from the community.
 
-## Contributor License Agreement (CLA)
+## Developer Certificate of Origin (DCO)
 
-Before contributing, you'll need to sign our Contributor License Agreement (CLA). This is a one-time requirement that covers all Radical AI open source projects. The CLA allows you to maintain ownership of your contributions while granting Radical AI the necessary rights to use them.
+This project uses a Developer Certificate of Origin to ensure that all contributions are appropriately licensed.
 
-[Radical AI CLA](https://www.radical-ai.com/oss)
+Every commit in your pull request must be "signed off" using the `-s` or `--signoff` flag with `git commit`:
 
-Our CLA-bot will automatically verify your signature on pull requests. For questions about the CLA, contact cla@radical-ai.com.
+```bash
+git commit -s -m "Your descriptive commit message"
+```
+
+This will add a `Signed-off-by:` line to the end of your commit message. By signing off on a commit, you are certifying that you agree to the terms of the DCO.
+
+<details>
+<summary>Click to view the full text of the Developer Certificate of Origin v1.1</summary>
+
+
+
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+
+</details>
+
 
 ## Code Reviews
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,8 +6,6 @@ TorchSim welcomes contributions and feedback from the community.
 
 By making a contribution to this project, you certify that you agree to the following:
 
-**Contributor's Certificate of Origin**
-
 (a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
 
 (b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,60 +2,19 @@
 
 TorchSim welcomes contributions and feedback from the community.
 
-## Developer Certificate of Origin (DCO)
+## Contributor's Certification
 
-This project uses a Developer Certificate of Origin to ensure that all contributions are appropriately licensed.
+By making a contribution to this project, you certify that you agree to the following:
 
-Every commit in your pull request must be "signed off" using the `-s` or `--signoff` flag with `git commit`:
+**Contributor's Certificate of Origin**
 
-```bash
-git commit -s -m "Your descriptive commit message"
-```
+(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or
 
-This will add a `Signed-off-by:` line to the end of your commit message. By signing off on a commit, you are certifying that you agree to the terms of the DCO.
+(b) The contribution is based upon previous work that, to the best of my knowledge, is covered under an appropriate open source license and I have the right under that license to submit that work with modifications, whether created in whole or in part by me, under the same open source license (unless I am permitted to submit under a different license), as indicated in the file; or
 
-<details>
-<summary>Click to view the full text of the Developer Certificate of Origin v1.1</summary>
+(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.
 
-
-
-Developer Certificate of Origin
-Version 1.1
-
-Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
-
-Everyone is permitted to copy and distribute verbatim copies of this
-license document, but changing it is not allowed.
-
-
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the best
-    of my knowledge, is covered under an appropriate open source
-    license and I have the right under that license to submit that
-    work with modifications, whether created in whole or in part
-    by me, under the same open source license (unless I am
-    permitted to submit under a different license), as indicated
-    in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including all
-    personal information I submit with it, including my sign-off) is
-    maintained indefinitely and may be redistributed consistent with
-    this project or the open source license(s) involved.
-
-</details>
-
+(d) I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.
 
 ## Code Reviews
 


### PR DESCRIPTION
## Summary

* Switch the repo from requiring a CLA to a new Contributor's Certification clause in [CONTRIBUTING.md](CONTRIBUTING.md) that users must agree to in PRs.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] I have read and agree to the Contributor's Certification in [CONTRIBUTING.md](CONTRIBUTING.md).

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
