### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ napoleon_use_rtype = True
 napoleon_use_ivar = True
 
 # The suffix(es) of source filenames.
-source_suffix = {".rst": "restructuredtext", ".md": "restructuredtext"}
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
 
 mathjax3_config = {
     "tex": {


### PR DESCRIPTION
## Summary

* The docs page at https://torchsim.github.io/torch-sim/ isn't rendering correctly. I built the docs locally and reproduced the issue. After making the little tweak in this PR and rebuilding, the docs seemed to render correctly. (Showing the landing page, but clicking around it seems like everything was fixed.) As I understand it there is an auto-build for the docs on merge to main, so this should be all that's needed.

Before:

![before](https://github.com/user-attachments/assets/0510ce98-994d-4f4c-a30b-ed19ef127845)


After:

<img width="1203" height="857" alt="Screenshot 2025-10-01 at 12 00 07 PM" src="https://github.com/user-attachments/assets/baaf727d-8780-446c-a1e2-cc6d12f3c3de" />

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.
* [x] I have read and agree to the Contributor's Certification in [CONTRIBUTING.md](CONTRIBUTING.md).

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
