### PR TITLE
Pull forward nequip framework from #264

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,6 +66,7 @@ jobs:
           - { name: mace, test_path: "tests/test_optimizers_vs_ase.py" }
           - { name: mattersim, test_path: "tests/models/test_mattersim.py" }
           - { name: metatomic, test_path: "tests/models/test_metatomic.py" }
+          - { name: nequip, test_path: "tests/models/test_nequip_framework.py" }
           - { name: orb, test_path: "tests/models/test_orb.py" }
           - { name: sevenn, test_path: "tests/models/test_sevennet.py" }
     runs-on: ${{ matrix.os }}
@@ -152,7 +153,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: 3.11
+          python-version: "3.12"
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,12 @@
 [project]
-name = "torch_sim_atomistic"
+name = "torch-sim-atomistic"
 version = "0.3.0"
 description = "A pytorch toolkit for calculating material properties using MLIPs"
 authors = [
     { name = "Abhijeet Gangan", email = "abhijeetgangan@g.ucla.edu" },
-    { name = "Janosh Riebesell", email = "jriebesell@radical-ai.com" },
-    { name = "Orion Cohen", email = "orion@radical-ai.com" },
-    { name = "Radical AI", email = "info@radical.ai" },
+    { name = "Janosh Riebesell", email = "janosh.riebesell@gmail.com" },
+    { name = "Orion Cohen", email = "orioncohen@berkeley.edu" },
+    { name = "Project TorchSim", email = "torchsimatomistic@gmail.com" },
 ]
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -28,7 +28,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "h5py>=3.12.1",
-    "numpy>=1.26",
+    "numpy>=2",
     "tables>=3.10.2",
     "torch>=2",
     "tqdm>=4.67",
@@ -37,21 +37,22 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-    "ase>=3.24",
+    "ase>=3.26",
     "phonopy>=2.37.0",
     "psutil>=7.0.0",
-    "pymatgen>=2024.11.3",
+    "pymatgen>=2025.6.14",
     "pytest-cov>=6",
     "pytest>=8",
 ]
-io = ["ase>=3.24", "phonopy>=2.37.0", "pymatgen>=2024.11.3"]
+io = ["ase>=3.26", "phonopy>=2.37.0", "pymatgen>=2025.6.14"]
 mace = ["mace-torch>=0.3.12"]
 mattersim = ["mattersim>=0.1.2"]
-metatomic = ["metatomic-torch>=0.1.1,<0.2", "metatrain[pet]==2025.7"]
+metatomic = ["metatomic-torch>=0.1.1,<0.2", "metatrain[pet]>=2025.7"]
 orb = ["orb-models>=0.5.2"]
-sevenn = ["sevenn>=0.11.0"]
+sevenn = ["sevenn>=0.11"]
 graphpes = ["graph-pes>=0.0.34", "mace-torch>=0.3.12"]
-fairchem = ["fairchem-core>=2.2.0"]
+nequip = ["nequip>=0.12"]
+fairchem = ["fairchem-core>=2.7"]
 docs = [
     "autodoc_pydantic==2.2.0",
     "furo==2024.8.6",
@@ -61,9 +62,9 @@ docs = [
     "jupytext==1.16.7",
     "myst_parser==4.0.0",
     "nbsphinx>=0.9.7",
-    "numpydoc==1.6.0",
+    "numpydoc==1.8.0",
     "sphinx-copybutton==0.5.2",
-    "sphinx==7.2.6",
+    "sphinx==8.1.3",
     "sphinx_design==0.6.1",
 ]
 
@@ -98,6 +99,7 @@ ignore = [
     "FIX002",  # Line contains TODO, consider resolving the issue
     "N803",    # Variable name should be lowercase
     "N806",    # Uppercase letters in variable names
+    "PLC0415", # import should be at the top-level of a file
     "PLR0912", # too many branches
     "PLR0913", # too many function arguments
     "PLR2004", # Magic value used in comparison, consider replacing {value} with a constant variable
@@ -121,15 +123,6 @@ pep8-naming.ignore-names = ["get_kT", "kT"]
 
 [tool.ruff.format]
 docstring-code-format = true
-
-[tool.mypy]
-warn_unused_configs = true
-ignore_missing_imports = true
-check_untyped_defs = true
-explicit_package_bases = true
-warn_unreachable = true
-warn_redundant_casts = true
-warn_unused_ignores = true
 
 [tool.codespell]
 check-filenames = true
@@ -160,11 +153,41 @@ conflicts = [
         { extra = "sevenn" },
     ],
     [
+        { extra = "graphpes" },
+        { extra = "fairchem" },
+    ],
+    [
+        { extra = "graphpes" },
+        { extra = "nequip" },
+    ],
+    [
+        { extra = "fairchem" },
+        { extra = "mace" },
+    ],
+    [
         { extra = "mace" },
         { extra = "mattersim" },
+    ],
+    [
+        { extra = "mace" },
+        { extra = "nequip" },
     ],
     [
         { extra = "mace" },
         { extra = "sevenn" },
     ],
 ]
+
+[dependency-groups]
+dev = ["prek>=0.2.0", "ty>=0.0.1a20"]
+
+[tool.ty.rules]
+# TODO: Unable to work with **kwargs: https://github.com/astral-sh/ty/issues/247
+missing-argument = "ignore"
+
+[[tool.ty.overrides]]
+include = ["tests/models/**/*.py", "torch_sim/models/**/*.py"]
+
+# TODO would be nice to only ignore unresolved model imports but fail on all other packages
+[tool.ty.overrides.rules]
+unresolved-import = "ignore"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,17 +177,3 @@ conflicts = [
         { extra = "sevenn" },
     ],
 ]
-
-[dependency-groups]
-dev = ["prek>=0.2.0", "ty>=0.0.1a20"]
-
-[tool.ty.rules]
-# TODO: Unable to work with **kwargs: https://github.com/astral-sh/ty/issues/247
-missing-argument = "ignore"
-
-[[tool.ty.overrides]]
-include = ["tests/models/**/*.py", "torch_sim/models/**/*.py"]
-
-# TODO would be nice to only ignore unresolved model imports but fail on all other packages
-[tool.ty.overrides.rules]
-unresolved-import = "ignore"

--- a/tests/models/conftest.py
+++ b/tests/models/conftest.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 import torch_sim as ts
+from tests.conftest import DEVICE
 from torch_sim.elastic import full_3x3_to_voigt_6_stress
 
 
@@ -23,6 +24,7 @@ consistency_test_simstate_fixtures: Final[tuple[str, ...]] = (
     "niti_sim_state",
     "ti_sim_state",
     "si_sim_state",
+    "rattled_si_sim_state",
     "sio2_sim_state",
     "rattled_sio2_sim_state",
     "ar_supercell_sim_state",
@@ -37,6 +39,8 @@ def make_model_calculator_consistency_test(
     model_fixture_name: str,
     calculator_fixture_name: str,
     sim_state_names: tuple[str, ...],
+    device: torch.device = DEVICE,
+    dtype: torch.dtype = torch.float64,
     energy_rtol: float = 1e-5,
     energy_atol: float = 1e-5,
     force_rtol: float = 1e-5,
@@ -61,10 +65,7 @@ def make_model_calculator_consistency_test(
 
     @pytest.mark.parametrize("sim_state_name", sim_state_names)
     def test_model_calculator_consistency(
-        sim_state_name: str,
-        request: pytest.FixtureRequest,
-        device: torch.device,
-        dtype: torch.dtype,
+        sim_state_name: str, request: pytest.FixtureRequest
     ) -> None:
         """Test consistency between model and calculator implementations."""
         # Get the model and calculator fixtures dynamically
@@ -124,6 +125,8 @@ def make_model_calculator_consistency_test(
 
 def make_validate_model_outputs_test(
     model_fixture_name: str,
+    device: torch.device = DEVICE,
+    dtype: torch.dtype = torch.float64,
 ):
     """Factory function to create model output validation tests.
 
@@ -132,11 +135,7 @@ def make_validate_model_outputs_test(
         model_fixture_name: Name of the model fixture to validate
     """
 
-    def test_model_output_validation(
-        request: pytest.FixtureRequest,
-        device: torch.device,
-        dtype: torch.dtype,
-    ) -> None:
+    def test_model_output_validation(request: pytest.FixtureRequest) -> None:
         """Test that a model implementation follows the ModelInterface contract."""
         # Get the model fixture dynamically
         model: ModelInterface = request.getfixturevalue(model_fixture_name)
@@ -170,7 +169,7 @@ def make_validate_model_outputs_test(
         og_positions = sim_state.positions.clone()
         og_cell = sim_state.cell.clone()
         og_batch = sim_state.system_idx.clone()
-        og_atomic_numbers = sim_state.atomic_numbers.clone()
+        og_atomic_nums = sim_state.atomic_numbers.clone()
 
         model_output = model.forward(sim_state)
 
@@ -178,7 +177,7 @@ def make_validate_model_outputs_test(
         assert torch.allclose(og_positions, sim_state.positions)
         assert torch.allclose(og_cell, sim_state.cell)
         assert torch.allclose(og_batch, sim_state.system_idx)
-        assert torch.allclose(og_atomic_numbers, sim_state.atomic_numbers)
+        assert torch.allclose(og_atomic_nums, sim_state.atomic_numbers)
 
         # assert model output has the correct keys
         assert "energy" in model_output

--- a/tests/models/test_fairchem_legacy.py
+++ b/tests/models/test_fairchem_legacy.py
@@ -2,8 +2,8 @@ import os
 import traceback
 
 import pytest
-import torch
 
+from tests.conftest import DEVICE
 from tests.models.conftest import (
     consistency_test_simstate_fixtures,
     make_model_calculator_consistency_test,
@@ -32,16 +32,16 @@ def model_path_oc20(tmp_path_factory: pytest.TempPathFactory) -> str:
 
 
 @pytest.fixture
-def eqv2_oc20_model_pbc(model_path_oc20: str, device: torch.device) -> FairChemV1Model:
-    cpu = device.type == "cpu"
+def eqv2_oc20_model_pbc(model_path_oc20: str) -> FairChemV1Model:
+    cpu = DEVICE.type == "cpu"
     return FairChemV1Model(model=model_path_oc20, cpu=cpu, seed=0, pbc=True)
 
 
 @pytest.fixture
 def eqv2_oc20_model_non_pbc(
-    model_path_oc20: str, device: torch.device
+    model_path_oc20: str,
 ) -> FairChemV1Model:
-    cpu = device.type == "cpu"
+    cpu = DEVICE.type == "cpu"
     return FairChemV1Model(model=model_path_oc20, cpu=cpu, seed=0, pbc=False)
 
 
@@ -55,9 +55,9 @@ if get_token():
 
     @pytest.fixture
     def eqv2_omat24_model_pbc(
-        model_path_omat24: str, device: torch.device
+        model_path_omat24: str,
     ) -> FairChemV1Model:
-        cpu = device.type == "cpu"
+        cpu = DEVICE.type == "cpu"
         return FairChemV1Model(model=model_path_omat24, cpu=cpu, seed=0, pbc=True)
 
 

--- a/tests/models/test_lennard_jones.py
+++ b/tests/models/test_lennard_jones.py
@@ -1,10 +1,11 @@
-"""Cheap integration tests ensuring different parts of torchsim work together."""
+"""Cheap integration tests ensuring different parts of TorchSim work together."""
 
 import pytest
 import torch
 from ase.build import bulk
 
 import torch_sim as ts
+from tests.conftest import DEVICE
 from torch_sim.models.interface import validate_model_outputs
 from torch_sim.models.lennard_jones import (
     LennardJonesModel,
@@ -136,11 +137,11 @@ def test_lennard_jones_force_energy_consistency() -> None:
 #       is not used in the neighbor list calculation. So to get correct results,
 #       we need a system that is large enough (2*cutoff).
 @pytest.fixture
-def ar_supercell_sim_state_large(device: torch.device) -> ts.SimState:
+def ar_supercell_sim_state_large() -> ts.SimState:
     """Create a face-centered cubic (FCC) Argon structure."""
     # Create FCC Ar using ASE, with 4x4x4 supercell
     ar_atoms = bulk("Ar", "fcc", a=5.26, cubic=True).repeat([4, 4, 4])
-    return ts.io.atoms_to_state(ar_atoms, device, torch.float64)
+    return ts.io.atoms_to_state(ar_atoms, DEVICE, torch.float64)
 
 
 @pytest.fixture
@@ -230,9 +231,6 @@ def test_stress_tensor_symmetry(
     assert torch.allclose(stress_tensor, stress_tensor.T, atol=1e-10)
 
 
-def test_validate_model_outputs(
-    lj_model: LennardJonesModel,
-    device: torch.device,
-) -> None:
+def test_validate_model_outputs(lj_model: LennardJonesModel) -> None:
     """Test that the model outputs are valid."""
-    validate_model_outputs(lj_model, device, torch.float64)
+    validate_model_outputs(lj_model, DEVICE, torch.float64)

--- a/tests/models/test_mattersim.py
+++ b/tests/models/test_mattersim.py
@@ -5,8 +5,8 @@ import traceback
 import ase.spacegroup
 import ase.units
 import pytest
-import torch
 
+from tests.conftest import DEVICE
 from tests.models.conftest import (
     consistency_test_simstate_fixtures,
     make_model_calculator_consistency_test,
@@ -25,59 +25,36 @@ except ImportError:
     )
 
 
-@pytest.fixture
-def dtype() -> torch.dtype:
-    """Fixture to provide the default dtype for testing."""
-    return torch.float32
+model_name = "mattersim-v1.0.0-1m.pth"
 
 
 @pytest.fixture
-def model_name() -> str:
-    """Fixture to provide the model name for testing. Load smaller 1M model
-    for testing purposes.
-    """
-    return "mattersim-v1.0.0-1m.pth"
-
-
-@pytest.fixture
-def pretrained_mattersim_model(device: torch.device, model_name: str):
+def pretrained_mattersim_model():
     """Load a pretrained MatterSim model for testing."""
     return Potential.from_checkpoint(
         load_path=model_name,
         model_name="m3gnet",
-        device=device,
+        device=DEVICE,
         load_training_state=False,
     )
 
 
 @pytest.fixture
-def mattersim_model(
-    pretrained_mattersim_model: Potential, device: torch.device
-) -> MatterSimModel:
+def mattersim_model(pretrained_mattersim_model: Potential) -> MatterSimModel:
     """Create an MatterSimModel wrapper for the pretrained model."""
-    return MatterSimModel(
-        model=pretrained_mattersim_model,
-        device=device,
-    )
+    return MatterSimModel(model=pretrained_mattersim_model, device=DEVICE)
 
 
 @pytest.fixture
-def mattersim_calculator(
-    pretrained_mattersim_model: Potential, device: torch.device
-) -> MatterSimCalculator:
+def mattersim_calculator(pretrained_mattersim_model: Potential) -> MatterSimCalculator:
     """Create an MatterSimCalculator for the pretrained model."""
-    return MatterSimCalculator(pretrained_mattersim_model, device=device)
+    return MatterSimCalculator(pretrained_mattersim_model, device=DEVICE)
 
 
-def test_mattersim_initialization(
-    pretrained_mattersim_model: Potential, device: torch.device
-) -> None:
+def test_mattersim_initialization(pretrained_mattersim_model: Potential) -> None:
     """Test that the MatterSim model initializes correctly."""
-    model = MatterSimModel(
-        model=pretrained_mattersim_model,
-        device=device,
-    )
-    assert model._device == device  # noqa: SLF001
+    model = MatterSimModel(model=pretrained_mattersim_model, device=DEVICE)
+    assert model.device == DEVICE
     assert model.stress_weight == ase.units.GPa
 
 

--- a/tests/models/test_metatomic.py
+++ b/tests/models/test_metatomic.py
@@ -3,6 +3,7 @@ import traceback
 import pytest
 import torch
 
+from tests.conftest import DEVICE
 from tests.models.conftest import (
     consistency_test_simstate_fixtures,
     make_model_calculator_consistency_test,
@@ -22,38 +23,27 @@ except ImportError:
 
 
 @pytest.fixture
-def dtype() -> torch.dtype:
-    """Fixture to provide the default dtype for testing."""
-    return torch.float32
-
-
-@pytest.fixture
-def metatomic_calculator(device: torch.device):
+def metatomic_calculator():
     """Load a pretrained metatomic model for testing."""
+    model_url = "https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt"
     return ase_calculator.MetatomicCalculator(
-        model=load_model(
-            "https://huggingface.co/lab-cosmo/pet-mad/resolve/v1.1.0/models/pet-mad-v1.1.0.ckpt"
-        ).export(),
-        device=device,
+        model=load_model(model_url).export(), device=DEVICE
     )
 
 
 @pytest.fixture
-def metatomic_model(device: torch.device) -> MetatomicModel:
+def metatomic_model() -> MetatomicModel:
     """Create an MetatomicModel wrapper for the pretrained model."""
-    return MetatomicModel(
-        model="pet-mad",
-        device=device,
-    )
+    return MetatomicModel(model="pet-mad", device=DEVICE)
 
 
-def test_metatomic_initialization(device: torch.device) -> None:
+def test_metatomic_initialization() -> None:
     """Test that the metatomic model initializes correctly."""
     model = MetatomicModel(
         model="pet-mad",
-        device=device,
+        device=DEVICE,
     )
-    assert model.device == device
+    assert model.device == DEVICE
     assert model.dtype == torch.float32
 
 
@@ -63,8 +53,12 @@ test_metatomic_consistency = make_model_calculator_consistency_test(
     calculator_fixture_name="metatomic_calculator",
     sim_state_names=consistency_test_simstate_fixtures,
     energy_atol=5e-5,
+    dtype=torch.float32,
+    device=DEVICE,
 )
 
 test_metatomic_model_outputs = make_validate_model_outputs_test(
     model_fixture_name="metatomic_model",
+    dtype=torch.float32,
+    device=DEVICE,
 )

--- a/tests/models/test_nequip_framework.py
+++ b/tests/models/test_nequip_framework.py
@@ -1,0 +1,84 @@
+import traceback
+import urllib.request
+from enum import StrEnum
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import DEVICE
+from tests.models.conftest import make_model_calculator_consistency_test
+
+
+try:
+    from nequip.ase import NequIPCalculator
+
+    from torch_sim.models.nequip_framework import (
+        NequIPFrameworkModel,
+        from_compiled_model,
+    )
+except (ImportError, ModuleNotFoundError):
+    pytest.skip(
+        f"nequip not installed: {traceback.format_exc()}", allow_module_level=True
+    )
+
+
+class NequIPUrls(StrEnum):
+    """Checkpoint download URLs for NequIP models."""
+
+    Si = "https://github.com/abhijeetgangan/pt_model_checkpoints/raw/refs/heads/main/nequip/Si.nequip.pth"
+
+
+@pytest.fixture(scope="session")
+def model_path_nequip(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_path = tmp_path_factory.mktemp("nequip_checkpoints")
+    model_name = "Si.nequip.pth"
+    model_path = Path(tmp_path) / model_name
+
+    if not model_path.is_file():
+        urllib.request.urlretrieve(NequIPUrls.Si, model_path)  # noqa: S310
+
+    return model_path
+
+
+@pytest.fixture
+def nequip_model(model_path_nequip: Path) -> NequIPFrameworkModel:
+    """Create an NequIPModel wrapper for the pretrained model."""
+    compiled_model, (r_max, type_names) = from_compiled_model(
+        model_path_nequip, device=DEVICE
+    )
+    return NequIPFrameworkModel(
+        model=compiled_model,
+        r_max=r_max,
+        type_names=type_names,
+        device=DEVICE,
+    )
+
+
+@pytest.fixture
+def nequip_calculator(model_path_nequip: Path) -> NequIPCalculator:
+    """Create an NequIPCalculator for the pretrained model."""
+    return NequIPCalculator.from_compiled_model(str(model_path_nequip), device=DEVICE)
+
+
+def test_nequip_initialization(model_path_nequip: Path) -> None:
+    """Test that the NequIP model initializes correctly."""
+    compiled_model, (r_max, type_names) = from_compiled_model(
+        model_path_nequip, device=DEVICE
+    )
+    model = NequIPFrameworkModel(
+        model=compiled_model,
+        r_max=r_max,
+        type_names=type_names,
+        device=DEVICE,
+    )
+    assert model._device == DEVICE  # noqa: SLF001
+
+
+test_nequip_consistency = make_model_calculator_consistency_test(
+    test_name="nequip",
+    model_fixture_name="nequip_model",
+    calculator_fixture_name="nequip_calculator",
+    sim_state_names=("si_sim_state", "rattled_si_sim_state"),
+)
+
+# TODO (AG): Test multi element models

--- a/tests/models/test_orb.py
+++ b/tests/models/test_orb.py
@@ -1,8 +1,8 @@
 import traceback
 
 import pytest
-import torch
 
+from tests.conftest import DEVICE
 from tests.models.conftest import (
     consistency_test_simstate_fixtures,
     make_model_calculator_consistency_test,
@@ -20,41 +20,33 @@ except ImportError:
 
 
 @pytest.fixture
-def orbv3_conservative_inf_omat_model(device: torch.device) -> OrbModel:
+def orbv3_conservative_inf_omat_model() -> OrbModel:
     orb_ff = pretrained.orb_v3_conservative_inf_omat(
-        device=device,
-        precision="float32-high",
+        device=DEVICE, precision="float32-high"
     )
-    return OrbModel(model=orb_ff, device=device)
+    return OrbModel(model=orb_ff, device=DEVICE)
 
 
 @pytest.fixture
-def orbv3_direct_20_omat_model(device: torch.device) -> OrbModel:
-    orb_ff = pretrained.orb_v3_direct_20_omat(
-        device=device,
-        precision="float32-high",
-    )
-    return OrbModel(model=orb_ff, device=device)
+def orbv3_direct_20_omat_model() -> OrbModel:
+    orb_ff = pretrained.orb_v3_direct_20_omat(device=DEVICE, precision="float32-high")
+    return OrbModel(model=orb_ff, device=DEVICE)
 
 
 @pytest.fixture
-def orbv3_conservative_inf_omat_calculator(device: torch.device) -> ORBCalculator:
+def orbv3_conservative_inf_omat_calculator() -> ORBCalculator:
     """Create an ORBCalculator for the pretrained model."""
     orb_ff = pretrained.orb_v3_conservative_inf_omat(
-        device=device,
-        precision="float32-high",
+        device=DEVICE, precision="float32-high"
     )
-    return ORBCalculator(model=orb_ff, device=device)
+    return ORBCalculator(model=orb_ff, device=DEVICE)
 
 
 @pytest.fixture
-def orbv3_direct_20_omat_calculator(device: torch.device) -> ORBCalculator:
+def orbv3_direct_20_omat_calculator() -> ORBCalculator:
     """Create an ORBCalculator for the pretrained model."""
-    orb_ff = pretrained.orb_v3_direct_20_omat(
-        device=device,
-        precision="float32-high",
-    )
-    return ORBCalculator(model=orb_ff, device=device)
+    orb_ff = pretrained.orb_v3_direct_20_omat(device=DEVICE, precision="float32-high")
+    return ORBCalculator(model=orb_ff, device=DEVICE)
 
 
 test_orb_conservative_consistency = make_model_calculator_consistency_test(

--- a/tests/models/test_sevennet.py
+++ b/tests/models/test_sevennet.py
@@ -3,6 +3,7 @@ import traceback
 import pytest
 import torch
 
+from tests.conftest import DEVICE
 from tests.models.conftest import (
     consistency_test_simstate_fixtures,
     make_model_calculator_consistency_test,
@@ -23,26 +24,13 @@ except ImportError:
     )
 
 
-@pytest.fixture
-def dtype() -> torch.dtype:
-    """Fixture to provide the default dtype for testing."""
-    return torch.float32
+model_name = "sevennet-mf-ompa"
+modal_name = "mpa"
+DTYPE = torch.float32
 
 
 @pytest.fixture
-def model_name() -> str:
-    """Fixture to provide the model name for testing."""
-    return "sevennet-mf-ompa"
-
-
-@pytest.fixture
-def modal_name() -> str:
-    """Fixture to provide the modal name for testing."""
-    return "mpa"
-
-
-@pytest.fixture
-def pretrained_sevenn_model(device: torch.device, model_name: str):
+def pretrained_sevenn_model():
     """Load a pretrained SevenNet model for testing."""
     cp = sevenn.util.load_checkpoint(model_name)
 
@@ -50,41 +38,27 @@ def pretrained_sevenn_model(device: torch.device, model_name: str):
     model_loaded = cp.build_model(backend)
     model_loaded.set_is_batch_data(True)
 
-    return model_loaded.to(device)
+    return model_loaded.to(DEVICE)
 
 
 @pytest.fixture
-def sevenn_model(
-    pretrained_sevenn_model: AtomGraphSequential, device: torch.device, modal_name: str
-) -> SevenNetModel:
+def sevenn_model(pretrained_sevenn_model: AtomGraphSequential) -> SevenNetModel:
     """Create an SevenNetModel wrapper for the pretrained model."""
-    return SevenNetModel(
-        model=pretrained_sevenn_model,
-        modal=modal_name,
-        device=device,
-    )
+    return SevenNetModel(model=pretrained_sevenn_model, modal=modal_name, device=DEVICE)
 
 
 @pytest.fixture
-def sevenn_calculator(
-    device: torch.device, model_name: str, modal_name: str
-) -> SevenNetCalculator:
+def sevenn_calculator() -> SevenNetCalculator:
     """Create an SevenNetCalculator for the pretrained model."""
-    return SevenNetCalculator(model_name, modal=modal_name, device=device)
+    return SevenNetCalculator(model_name, modal=modal_name, device=DEVICE)
 
 
-def test_sevennet_initialization(
-    pretrained_sevenn_model: AtomGraphSequential, device: torch.device
-) -> None:
+def test_sevennet_initialization(pretrained_sevenn_model: AtomGraphSequential) -> None:
     """Test that the SevenNet model initializes correctly."""
-    model = SevenNetModel(
-        model=pretrained_sevenn_model,
-        modal="omat24",
-        device=device,
-    )
+    model = SevenNetModel(model=pretrained_sevenn_model, modal="omat24", device=DEVICE)
     # Check that properties were set correctly
     assert model.modal == "omat24"
-    assert model._device == device  # noqa: SLF001
+    assert model.device == DEVICE
 
 
 # NOTE: we take [:-1] to skipbenzene due to eps volume giving numerically
@@ -94,9 +68,10 @@ test_sevennet_consistency = make_model_calculator_consistency_test(
     model_fixture_name="sevenn_model",
     calculator_fixture_name="sevenn_calculator",
     sim_state_names=consistency_test_simstate_fixtures[:-1],
+    dtype=DTYPE,
 )
 
 
 test_sevennet_model_outputs = make_validate_model_outputs_test(
-    model_fixture_name="sevenn_model",
+    model_fixture_name="sevenn_model", dtype=DTYPE
 )

--- a/torch_sim/models/interface.py
+++ b/torch_sim/models/interface.py
@@ -1,6 +1,6 @@
-"""Core interfaces for all models in torchsim.
+"""Core interfaces for all models in TorchSim.
 
-This module defines the abstract base class that all torchsim models must implement.
+This module defines the abstract base class that all TorchSim models must implement.
 It establishes a common API for interacting with different force and energy models,
 ensuring consistent behavior regardless of the underlying implementation. The module
 also provides validation utilities to verify model conformance to the interface.
@@ -36,7 +36,7 @@ from torch_sim.typing import MemoryScaling, StateDict
 
 
 class ModelInterface(torch.nn.Module, ABC):
-    """Abstract base class for all simulation models in torchsim.
+    """Abstract base class for all simulation models in TorchSim.
 
     This interface provides a common structure for all energy and force models,
     ensuring they implement the required methods and properties. It defines how
@@ -208,14 +208,14 @@ def validate_model_outputs(  # noqa: C901, PLR0915
 
     try:
         if not model.compute_stress:
-            model.compute_stress = True
+            model.compute_stress = True  # type: ignore[unresolved-attribute]
         stress_computed = True
     except NotImplementedError:
         stress_computed = False
 
     try:
         if not model.compute_forces:
-            model.compute_forces = True
+            model.compute_forces = True  # type: ignore[unresolved-attribute]
         force_computed = True
     except NotImplementedError:
         force_computed = False
@@ -228,7 +228,7 @@ def validate_model_outputs(  # noqa: C901, PLR0915
     og_positions = sim_state.positions.clone()
     og_cell = sim_state.cell.clone()
     og_system_idx = sim_state.system_idx.clone()
-    og_atomic_numbers = sim_state.atomic_numbers.clone()
+    og_atomic_nums = sim_state.atomic_numbers.clone()
 
     model_output = model.forward(sim_state)
 
@@ -239,8 +239,8 @@ def validate_model_outputs(  # noqa: C901, PLR0915
         raise ValueError(f"{og_cell=} != {sim_state.cell=}")
     if not torch.allclose(og_system_idx, sim_state.system_idx):
         raise ValueError(f"{og_system_idx=} != {sim_state.system_idx=}")
-    if not torch.allclose(og_atomic_numbers, sim_state.atomic_numbers):
-        raise ValueError(f"{og_atomic_numbers=} != {sim_state.atomic_numbers=}")
+    if not torch.allclose(og_atomic_nums, sim_state.atomic_numbers):
+        raise ValueError(f"{og_atomic_nums=} != {sim_state.atomic_numbers=}")
 
     # assert model output has the correct keys
     if "energy" not in model_output:

--- a/torch_sim/models/nequip_framework.py
+++ b/torch_sim/models/nequip_framework.py
@@ -1,0 +1,379 @@
+"""Wrapper for NequIP-Allegro models in TorchSim.
+
+This module provides a TorchSim wrapper of the NequIP-Allegro models for computing
+energies, forces, and stresses for atomistic systems. It integrates the NequIP-Allegro
+models with TorchSim's simulation framework, handling batched computations for multiple
+systems simultaneously.
+
+The implementation supports various features including:
+
+* Computing energies, forces, and stresses
+* Batched calculations for multiple systems
+
+References:
+    - NequIP Package: https://github.com/mir-group/nequip
+"""
+
+import traceback
+import warnings
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import ase.data
+import torch
+
+import torch_sim as ts
+from torch_sim.models.interface import ModelInterface
+from torch_sim.neighbors import vesin_nl_ts
+from torch_sim.typing import StateDict
+
+
+try:
+    from nequip.model.inference_models import load_compiled_model
+    from nequip.nn import graph_model
+    from nequip.scripts._compile_utils import ASE_OUTPUTS, PAIR_NEQUIP_INPUTS
+except ImportError as exc:
+    warnings.warn(f"NequIP import failed: {traceback.format_exc()}", stacklevel=2)
+
+    class NequIPFrameworkModel(ModelInterface):
+        """NequIP model wrapper for torch-sim.
+
+        This class is a placeholder for the NequIPModel class.
+        It raises an ImportError if NequIP is not installed.
+        """
+
+        def __init__(self, err: ImportError = exc, *_args: Any, **_kwargs: Any) -> None:
+            """Dummy init for type checking."""
+            raise err
+
+
+class ChemicalSpeciesToAtomTypeMapper:
+    """Maps atomic numbers to model-specific atom type indices.
+
+    This class provides functionality to map atomic numbers to the corresponding atom type
+    indices used by the model. It handles cases where the model's internal representation
+    of atom types may differ from conventional chemical species, such as when modeling
+    different charge states of the same element.
+
+    The mapping is created using a lookup table that converts atomic numbers to
+    zero-based indices based on the provided list of chemical symbols. The order of
+    chemical symbols must match the order of atom types expected by the model.
+
+    NOTE: This is adapted from the NequIP package.
+
+    Attributes:
+        lookup_table (torch.Tensor): Tensor mapping atomic numbers to model type indices.
+            Contains -1 for unmapped atomic numbers.
+
+    Args:
+        chemical_symbols (list[str]): List of chemical symbols in the order matching
+            the model's internal type ordering. Each symbol must be a valid chemical
+            element symbol.
+
+    Raises:
+        AssertionError: If an invalid chemical symbol is provided.
+    """
+
+    def __init__(self, chemical_symbols: list[str]) -> None:  # noqa: D107
+        # Create lookup table mapping atomic numbers to model type indices
+        self.lookup_table = torch.full(
+            (max(ase.data.atomic_numbers.values()),), -1, dtype=torch.long
+        )
+        for idx, sym in enumerate(chemical_symbols):
+            assert sym in ase.data.atomic_numbers, f"Invalid chemical symbol {sym}"  # noqa: S101
+            self.lookup_table[ase.data.atomic_numbers[sym]] = idx
+
+    def __call__(self, atomic_numbers: torch.Tensor) -> torch.Tensor:
+        """Convert atomic numbers to model-specific atom type indices.
+
+        Args:
+            atomic_numbers (torch.Tensor): Tensor of atomic numbers to convert.
+
+        Returns:
+            torch.Tensor: Atom type indices used by the model.
+        """
+        return torch.index_select(self.lookup_table, 0, atomic_numbers)
+
+
+def from_compiled_model(
+    compile_path: str | Path, device: str | torch.device = "cpu"
+) -> tuple[torch.nn.Module, tuple[float, list[str]]]:
+    """Load a compiled NequIP model from a file.
+
+    Loads a compiled NequIP model from a file and extracts the necessary metadata
+    for using it in TorchSim. The model must have been compiled using nequip-compile.
+
+    Args:
+        compile_path (str): Path to the compiled model file. The file should have been
+            created using nequip-compile.
+        device (str | torch.device): Device to load the model on. Can be either a string
+            like 'cpu' or 'cuda', or a torch.device object. Defaults to 'cpu'.
+
+    Returns:
+        tuple[torch.nn.Module, tuple[float, list[str]]]: A tuple containing:
+            - The loaded NequIP model as a torch.nn.Module
+            - A tuple with:
+                - r_max (float): Cutoff radius used by the model
+                - type_names (list[str]): List of chemical symbols supported by the model
+
+    Example:
+        >>> model, (r_max, type_names) = from_compiled_model("model.pth", device="cuda")
+        >>> print(f"Model cutoff: {r_max:.2f}")
+        >>> print(f"Supported elements: {type_names}")
+
+    References:
+        For model compilation please refer to the NequIP documentation:
+            https://nequip.readthedocs.io/en/latest/guide/getting-started/workflow.html#compilation
+    """
+    model, metadata = load_compiled_model(
+        str(compile_path), device, PAIR_NEQUIP_INPUTS, ASE_OUTPUTS
+    )
+
+    # extract r_max and type_names for transforms
+    r_max = metadata[graph_model.R_MAX_KEY]
+    type_names = metadata[graph_model.TYPE_NAMES_KEY]
+
+    return model, (r_max, type_names)
+
+
+class NequIPFrameworkModel(ModelInterface):
+    """NequIP model for energy, force and stress calculations.
+
+    This class wraps a NequIP model to compute energies, forces and stresses
+    for atomic systems.
+
+    Args:
+        model (torch.nn.Module): The NequIP model to use. Must be a torch.nn.Module.
+        r_max (float): Cutoff radius for neighbor list construction.
+        type_names (list[str]): List of chemical symbols supported by the model.
+        device (torch.device | None): Device to run calculations on.
+            Defaults to CUDA if available, otherwise CPU.
+        neighbor_list_fn (Callable): Function to compute neighbor lists.
+            Defaults to vesin_nl_ts.
+        atomic_numbers (torch.Tensor | None): Atomic numbers with shape [n_atoms].
+            If provided at initialization, cannot be provided again during forward pass.
+        system_idx (torch.Tensor | None): Batch indices with shape [n_atoms] indicating
+            which system each atom belongs to. If not provided with atomic_numbers,
+            all atoms are assumed to be in the same system.
+    """
+
+    def __init__(
+        self,
+        model: str | Path | torch.nn.Module | None = None,
+        *,
+        r_max: float,
+        type_names: list[str],
+        device: torch.device | None = None,
+        neighbor_list_fn: Callable = vesin_nl_ts,
+        atomic_numbers: torch.Tensor | None = None,
+        system_idx: torch.Tensor | None = None,
+    ) -> None:
+        """Initialize the NequIP model.
+
+        Args:
+            model: The NequIP model to use. Must be a torch.nn.Module.
+            r_max: Cutoff radius for neighbor list construction.
+            type_names: List of chemical symbols supported by the model.
+            device: Device to run calculations on.
+                Defaults to CUDA if available, otherwise CPU.
+            neighbor_list_fn: Function to compute neighbor lists. Defaults to vesin_nl_ts.
+            atomic_numbers: Atomic numbers with shape [n_atoms]. If provided at
+                initialization, cannot be provided again during forward pass.
+            system_idx: Batch indices with shape [n_atoms] indicating which system
+                each atom belongs to. If not provided with atomic_numbers, all atoms
+                are assumed to be in the same system. If provided, must be a tensor
+                of long integers.
+
+        Raises:
+            TypeError: If model is not a torch.nn.Module.
+        """
+        super().__init__()
+        self._device = device or torch.device(
+            "cuda" if torch.cuda.is_available() else "cpu"
+        )
+        self.neighbor_list_fn = neighbor_list_fn
+        self._memory_scales_with = "n_atoms_x_density"
+        self._compute_forces = True
+        self._compute_stress = True
+
+        if isinstance(model, torch.nn.Module):
+            self.model = model
+        else:
+            raise TypeError("Invalid model type. Must be a torch.nn.Module.")
+
+        # Set model properties
+        # using float64 for the cutoff radius (neighbor list)
+        self.r_max = torch.tensor(r_max, dtype=torch.float64, device=self.device)
+        self.type_names = type_names
+
+        # Store flag to track if atomic numbers were provided at init
+        self.atomic_numbers_in_init = atomic_numbers is not None
+        self.n_systems = system_idx.max().item() + 1 if system_idx is not None else 1
+
+        # Set up batch information if atomic numbers are provided
+        if atomic_numbers is not None:
+            if system_idx is None:
+                # If batch is not provided, assume all atoms belong to same system
+                system_idx = torch.zeros(
+                    len(atomic_numbers), dtype=torch.long, device=self.device
+                )
+
+            self.setup_from_system_idx(atomic_numbers, system_idx)
+
+    def setup_from_system_idx(
+        self, atomic_numbers: torch.Tensor, system_idx: torch.Tensor
+    ) -> None:
+        """Set up internal state from atomic numbers and system indices.
+
+        Processes the atomic numbers and system indices to prepare the model for
+        forward pass calculations. Creates the necessary data structures for
+        batched processing of multiple systems.
+
+        Args:
+            atomic_numbers (torch.Tensor): Atomic numbers tensor with shape [n_atoms].
+            system_idx (torch.Tensor): System indices tensor with shape [n_atoms]
+                indicating which system each atom belongs to.
+        """
+        self.atomic_numbers = atomic_numbers
+        self.system_idx = system_idx
+        self.atomic_types = ChemicalSpeciesToAtomTypeMapper(self.type_names)(
+            atomic_numbers
+        )
+
+        # Determine number of systems and atoms per system
+        self.n_systems = system_idx.max().item() + 1
+        self.total_atoms = atomic_numbers.shape[0]
+
+    def forward(self, state: ts.SimState | StateDict) -> dict[str, torch.Tensor]:  # noqa: C901
+        """Compute energies, forces, and stresses for the given atomic systems.
+
+        Processes the provided state information and computes energies, forces, and
+        stresses using the underlying MACE model. Handles batched calculations for
+        multiple systems and constructs the necessary neighbor lists.
+
+        Args:
+            state (SimState | StateDict): State object containing positions, cell,
+                and other system information. Can be either a SimState object or a
+                dictionary with the relevant fields.
+
+        Returns:
+            dict[str, torch.Tensor]: Computed properties:
+                - 'energy': System energies with shape [n_systems]
+                - 'forces': Atomic forces with shape [n_atoms, 3] if compute_forces=True
+                - 'stress': System stresses with shape [n_systems, 3, 3] if
+                    compute_stress=True
+
+        Raises:
+            ValueError: If atomic numbers are not provided either in the constructor
+                or in the forward pass, or if provided in both places.
+            ValueError: If system indices are not provided when needed.
+        """
+        sim_state = (
+            state
+            if isinstance(state, ts.SimState)
+            else ts.SimState(**state, masses=torch.ones_like(state["positions"]))
+        )
+
+        # Handle input validation for atomic numbers
+        if sim_state.atomic_numbers is None and not self.atomic_numbers_in_init:
+            raise ValueError(
+                "Atomic numbers must be provided in either the constructor or forward."
+            )
+        if sim_state.atomic_numbers is not None and self.atomic_numbers_in_init:
+            raise ValueError(
+                "Atomic numbers cannot be provided in both the constructor and forward."
+            )
+
+        # Use system_idx from init if not provided
+        if sim_state.system_idx is None:
+            if not hasattr(self, "system_idx"):
+                raise ValueError(
+                    "System indices must be provided if not set during initialization"
+                )
+            sim_state.system_idx = self.system_idx
+
+        # Update batch information if new atomic numbers are provided
+        if (
+            sim_state.atomic_numbers is not None
+            and not self.atomic_numbers_in_init
+            and not torch.equal(
+                sim_state.atomic_numbers,
+                getattr(self, "atomic_numbers", torch.zeros(0, device=self.device)),
+            )
+        ):
+            self.setup_from_system_idx(sim_state.atomic_numbers, sim_state.system_idx)
+
+        # Process each system's neighbor list separately
+        edge_indices = []
+        shifts_list = []
+        unit_shifts_list = []
+        offset = 0
+
+        # TODO (AG): Currently doesn't work for batched neighbor lists
+        for sys_idx in range(self.n_systems):
+            system_idx_mask = sim_state.system_idx == sys_idx
+            # Calculate neighbor list for this system
+            edge_idx, shifts_idx = self.neighbor_list_fn(
+                positions=sim_state.positions[system_idx_mask],
+                cell=sim_state.row_vector_cell[sys_idx],
+                pbc=sim_state.pbc,
+                cutoff=self.r_max,
+            )
+
+            # Adjust indices for the batch
+            edge_idx = edge_idx + offset
+            shifts = torch.mm(shifts_idx, sim_state.row_vector_cell[sys_idx])
+
+            edge_indices.append(edge_idx)
+            unit_shifts_list.append(shifts_idx)
+            shifts_list.append(shifts)
+
+            offset += len(sim_state.positions[system_idx_mask])
+
+        # Combine all neighbor lists
+        edge_index = torch.cat(edge_indices, dim=1)
+        unit_shifts = torch.cat(unit_shifts_list, dim=0)
+        shifts = torch.cat(shifts_list, dim=0)
+        atomic_types = ChemicalSpeciesToAtomTypeMapper(self.type_names)(
+            sim_state.atomic_numbers
+        )
+
+        # Get model output
+        data: dict[str, torch.Tensor] = {
+            "pos": sim_state.positions,
+            "cell": sim_state.row_vector_cell,
+            "batch": sim_state.system_idx,
+            "num_atoms": sim_state.system_idx.bincount(),
+            "pbc": torch.tensor(
+                [sim_state.pbc, sim_state.pbc, sim_state.pbc],
+                dtype=torch.bool,
+                device=self.device,
+            ),
+            "atomic_numbers": sim_state.atomic_numbers,
+            "atom_types": atomic_types,
+            "edge_index": edge_index,
+            "edge_cell_shift": unit_shifts,
+        }
+        out = self.model(data)
+        results: dict[str, torch.Tensor] = {}
+        # Process energy
+        energy = out["total_energy"]
+        if energy is None:
+            results["energy"] = torch.zeros(self.n_systems, device=self.device)
+        else:
+            results["energy"] = energy.detach()
+
+        # Process forces
+        if self.compute_forces:
+            forces = out["forces"]
+            if forces is not None:
+                results["forces"] = forces.detach()
+
+        # Process stress
+        if self.compute_stress:
+            stress = out["stress"]
+            if stress is not None:
+                results["stress"] = stress.detach()
+
+        return results


### PR DESCRIPTION
## Summary
* Brings forward Nequip framework changes from #264.
* Decouples model changes from integration changes in #264.
* Allows @falletta to look into allegro-pol in ts.

currently blocked by https://github.com/issues/created?issue=mir-group%7Cnequip%7C553

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the pre-commit hooks running in CI locally to speedup the development process. Simply run `pip install pre-commit && pre-commit install` to install the hooks which will check your code before each commit.
