### PR TITLE
Remove unused imports orb and updates class type check

### DIFF
--- a/torch_sim/models/orb.py
+++ b/torch_sim/models/orb.py
@@ -33,8 +33,6 @@ try:
     from orb_models.forcefield import featurization_utilities as feat_util
     from orb_models.forcefield.atomic_system import SystemConfig
     from orb_models.forcefield.base import AtomGraphs, _map_concat
-    from orb_models.forcefield.featurization_utilities import EdgeCreationMethod
-    from orb_models.forcefield.graph_regressor import GraphRegressor
 
 except ImportError as exc:
     warnings.warn(f"Orb import failed: {traceback.format_exc()}", stacklevel=2)
@@ -55,8 +53,8 @@ if typing.TYPE_CHECKING:
     from orb_models.forcefield.conservative_regressor import (
         ConservativeForcefieldRegressor,
     )
+    from orb_models.forcefield.direct_regressor import DirectForcefieldRegressor
     from orb_models.forcefield.featurization_utilities import EdgeCreationMethod
-    from orb_models.forcefield.graph_regressor import GraphRegressor
 
     from torch_sim.typing import StateDict
 
@@ -256,7 +254,8 @@ class OrbModel(ModelInterface):
     predictions.
 
     Attributes:
-        model (Union[GraphRegressor, ConservativeForcefieldRegressor]): The ORB model
+        model (Union[DirectForcefieldRegressor, ConservativeForcefieldRegressor]):
+            The ORB model
         system_config (SystemConfig): Configuration for the atomic system
         conservative (bool): Whether to use conservative forces/stresses calculation
         implemented_properties (list): Properties the model can compute
@@ -274,7 +273,7 @@ class OrbModel(ModelInterface):
 
     def __init__(
         self,
-        model: GraphRegressor | ConservativeForcefieldRegressor | str | Path,
+        model: DirectForcefieldRegressor | ConservativeForcefieldRegressor | str | Path,
         *,  # force remaining arguments to be keyword-only
         conservative: bool | None = None,
         compute_stress: bool = True,
@@ -292,7 +291,7 @@ class OrbModel(ModelInterface):
         Sets up the model parameters for subsequent use in energy and force calculations.
 
         Args:
-            model (Union[GraphRegressor, ConservativeForcefieldRegressor, str, Path]):
+            model (DirectForcefieldRegressor|ConservativeForcefieldRegressor|str|Path):
                 Either a model object or a path to a saved model
             conservative (bool | None): Whether to use conservative forces/stresses
                 If None, determined based on model type


### PR DESCRIPTION
## Summary
removed GraphRegressor which causes import error, catched by try except so it wouldn't crash.
Replace under TYPE_CHECKING by DirectForceFieldRegressor which replaced GraphRegressor in April 25 in orb-models

## Checklist

Before a pull request can be merged, the following items must be checked:

* [X] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [X] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [X] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit.
