### PR TITLE
Skip FairChem tests on forks due to HF secret.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,7 @@ jobs:
           uv pip install -e ".[test,${{ matrix.model.name }}]" --resolution=${{ matrix.version.resolution }} --system
 
       - name: Run ${{ matrix.model.test_path }} tests
+        if: ${{ !contains(matrix.model.name, 'fairchem') || github.event.pull_request.head.repo.fork == false }}
         env:
           HF_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
         run: |
@@ -169,6 +170,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Run example
+        if: ${{ !contains(matrix.example, 'fairchem') || github.event.pull_request.head.repo.fork == false }}
         env:
           HF_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
         run: |


### PR DESCRIPTION
## Summary

Will skip fairchem tests on forks to allow forks to hit merge criteria. This is not a true fix as it skips the tests but it prevents the failures which make end users more likely to ignore other test issues.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit.
