### PR TITLE
fix graph-pes key issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ mattersim = ["mattersim>=0.1.2"]
 metatomic = ["metatomic-torch>=0.1.1", "metatrain[pet]>=2025.7"]
 orb = ["orb-models>=0.5.2"]
 sevenn = ["sevenn>=0.11.0"]
-graphpes = ["graph-pes>=0.0.34,<=0.2.0", "mace-torch>=0.3.12"]
+graphpes = ["graph-pes>=0.1", "mace-torch>=0.3.12"]
 nequip = ["nequip>=0.12.0"]
 fairchem = ["fairchem-core>=2.7"]
 docs = [

--- a/torch_sim/models/graphpes.py
+++ b/torch_sim/models/graphpes.py
@@ -85,7 +85,10 @@ def state_to_atomic_graph(state: ts.SimState, cutoff: torch.Tensor) -> AtomicGra
             neighbour_cell_offsets=shifts,
             properties={},
             cutoff=cutoff.item(),
-            other={},
+            other={
+                "total_charge": torch.tensor(0.0).to(state.device),
+                "total_spin": torch.tensor(0.0).to(state.device),
+            },
         )
         graphs.append(atomic_graph)
 


### PR DESCRIPTION
## Summary

To support the new MACE-OMOL, and other, models, `graph-pes` now sometimes expects a total charge and total spin for each system. This PR sets these values to the default 0, unblocking #280 

In the future, are there plans to incorporate these data into the `SimState` class?

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit.
