### PR TITLE
Fix calculate static state after relax

### DIFF
--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -579,8 +579,8 @@ def static(
         forces: torch.Tensor
         stress: torch.Tensor
 
-        _atom_attributes = state._atom_attributes | {"forces"}  # noqa: SLF001
-        _system_attributes = state._system_attributes | {  # noqa: SLF001
+        _atom_attributes = SimState._atom_attributes | {"forces"}  # noqa: SLF001
+        _system_attributes = SimState._system_attributes | {  # noqa: SLF001
             "energy",
             "stress",
         }
@@ -605,9 +605,13 @@ def static(
             )
 
         model_outputs = model(sub_state)
-
-        sub_state = StaticState(
-            **vars(sub_state),
+        static_state = StaticState(
+            positions=sub_state.positions,
+            masses=sub_state.masses,
+            cell=sub_state.cell,
+            pbc=sub_state.pbc,
+            atomic_numbers=sub_state.atomic_numbers,
+            system_idx=sub_state.system_idx,
             energy=model_outputs["energy"],
             forces=(
                 model_outputs["forces"]
@@ -621,11 +625,11 @@ def static(
             ),
         )
 
-        props = trajectory_reporter.report(sub_state, 0, model=model)
+        props = trajectory_reporter.report(static_state, 0, model=model)
         all_props.extend(props)
 
         if tqdm_pbar:
-            tqdm_pbar.update(sub_state.n_systems)
+            tqdm_pbar.update(static_state.n_systems)
 
     trajectory_reporter.finish()
 


### PR DESCRIPTION
## Summary

Before this change, we'd get this error

```
TypeError: torch_sim.runners.static.<locals>.StaticState() got multiple values for keyword argument 'energy'
```
This is because we were creating a static_state but passing in fields that already existed (because we optimized the state before calculating the static property). Since we used **vars() to initialize the static state, we'd pass properties like energies twice into the constructor for StaticState.

To fix this PR I also had to make StaticState's attributes be dependent on only SimState's attributes.
Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
