### PR TITLE
fix PBC on GPU bug in `state_to_atoms`

### DIFF
--- a/torch_sim/io.py
+++ b/torch_sim/io.py
@@ -53,6 +53,7 @@ def state_to_atoms(state: "ts.SimState") -> list["Atoms"]:
     cell = state.cell.detach().cpu().numpy()  # Shape: (n_systems, 3, 3)
     atomic_numbers = state.atomic_numbers.detach().cpu().numpy()
     system_indices = state.system_idx.detach().cpu().numpy()
+    pbc = state.pbc.detach().cpu().numpy()
 
     atoms_list = []
     for sys_idx in np.unique(system_indices):
@@ -65,7 +66,7 @@ def state_to_atoms(state: "ts.SimState") -> list["Atoms"]:
         symbols = [chemical_symbols[z] for z in system_numbers]
 
         atoms = Atoms(
-            symbols=symbols, positions=system_positions, cell=system_cell, pbc=state.pbc
+            symbols=symbols, positions=system_positions, cell=system_cell, pbc=pbc
         )
         atoms_list.append(atoms)
 


### PR DESCRIPTION
## Summary

Bug likely appeared because PBC is not a `torch.Tensor` instead of just a bool (https://github.com/TorchSim/torch-sim/pull/320). This failure mode only shows up when running on GPU, which explains why CI didn't catch it (presumably it's only run on CPU). I didn't check the other format conversion utility functions, but potentially some of the others might have a similar failure mode if they were not changed with the breaking PBC internal behavior change. 

```
  File "/home/cw/harvard/matbench-discovery/models/nequip/torchsim_evals/test_nequip_discovery.py", line 172, in <module>
    relaxed_atoms_list = ts.io.state_to_atoms(final_state)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/cw/harvard/torch-sim/torch_sim/io.py", line 67, in state_to_atoms
    atoms = Atoms(
            ^^^^^^
  File "/home/cw/micromamba/envs/nequip/lib/python3.12/site-packages/ase/atoms.py", line 254, in __init__
    self.set_pbc(pbc)
  File "/home/cw/micromamba/envs/nequip/lib/python3.12/site-packages/ase/atoms.py", line 571, in set_pbc
    self.pbc = pbc
    ^^^^^^^^
  File "/home/cw/micromamba/envs/nequip/lib/python3.12/site-packages/ase/atoms.py", line 567, in pbc
    self._pbc[:] = pbc
    ~~~~~~~~~^^^
  File "/home/cw/micromamba/envs/nequip/lib/python3.12/site-packages/torch/_tensor.py", line 1213, in __array__
    return self.numpy().astype(dtype, copy=False)
           ^^^^^^^^^^^^
TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
