### PR TITLE
Fix: add init_kwargs to ts.integrate

### DIFF
--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -100,6 +100,7 @@ def test_integrate_double_nvt(
         n_steps=10,
         temperature=100.0,  # K
         timestep=0.001,  # ps
+        init_kwargs=dict(seed=481516),
     )
 
     assert isinstance(final_state, SimState)

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -111,6 +111,7 @@ def integrate[T: SimState](  # noqa: C901
     trajectory_reporter: TrajectoryReporter | dict | None = None,
     autobatcher: BinningAutoBatcher | bool = False,
     pbar: bool | dict[str, Any] = False,
+    init_kwargs: dict[str, Any] | None = None,
     **integrator_kwargs: Any,
 ) -> T:
     """Simulate a system using a model and integrator.
@@ -131,6 +132,8 @@ def integrate[T: SimState](  # noqa: C901
         pbar (bool | dict[str, Any], optional): Show a progress bar.
             Only works with an autobatcher in interactive shell. If a dict is given,
             it's passed to `tqdm` as kwargs.
+        init_kwargs (dict[str, Any], optional): Additional keyword arguments for
+            integrator init function.
         **integrator_kwargs: Additional keyword arguments for integrator init function
 
     Returns:
@@ -189,7 +192,7 @@ def integrate[T: SimState](  # noqa: C901
     # Handle both BinningAutoBatcher and list of tuples
     for state, system_indices in batch_iterator:
         # Pass correct parameters based on integrator type
-        state = init_func(state=state, model=model, kT=kTs[0], dt=dt, **integrator_kwargs)
+        state = init_func(state=state, model=model, kT=kTs[0], dt=dt, **init_kwargs or {})
 
         # set up trajectory reporters
         if autobatcher and trajectory_reporter is not None and og_filenames is not None:


### PR DESCRIPTION
## Summary
Closes https://github.com/TorchSim/torch-sim/issues/355.

This resolves an issue where it is not possible to pass dedicated arguments only to the integrator's init function (but not to step). This PR fixes this by taking inspiration from `ts.optimize`. Also adding an init_kwarg to one of the test cases.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
