### PR TITLE
Fix PBC extraction to CPU fairchem model

### DIFF
--- a/torch_sim/models/fairchem.py
+++ b/torch_sim/models/fairchem.py
@@ -206,8 +206,8 @@ class FairChemModel(ModelInterface):
             zip(n_atoms, torch.cumsum(n_atoms, dim=0), strict=False)
         ):
             # Extract system data
-            positions = sim_state.positions[c - n: c].cpu().numpy()
-            atomic_nums = sim_state.atomic_numbers[c - n: c].cpu().numpy()
+            positions = sim_state.positions[c - n : c].cpu().numpy()
+            atomic_nums = sim_state.atomic_numbers[c - n : c].cpu().numpy()
             pbc = sim_state.pbc.cpu().numpy()
             cell = (
                 sim_state.row_vector_cell[idx].cpu().numpy()


### PR DESCRIPTION
## Summary

Related to #346 : PBC variable was also retreived from GPU tensor in fairchem.py, leading to TypeErrors in ASE. Added simple fix.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
