### PR TITLE
Fix fairchem-legacy tests by removing explicit Hugging Face login

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,7 +192,6 @@ jobs:
           HF_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
         run: |
           if [[ "${{ matrix.example }}" == *"fairchem"* ]]; then
-            uv pip install "huggingface_hub[cli]" --system
-            hf auth login --token "$HF_TOKEN"
+            uv pip install huggingface_hub --system
           fi
           uv run --with . ${{ matrix.example }}


### PR DESCRIPTION
## Summary

The fairchem-legacy tests have been failing like this:

```
Run if [[ "fairchem-legacy" == *"fairchem"* ]]; then
  if [[ "fairchem-legacy" == *"fairchem"* ]]; then
    uv pip install "huggingface_hub[cli]" --system
    hf auth login --token "$HF_TOKEN"
  fi
  pytest -vv -ra -rs --cov=torch_sim --cov-report=xml tests/models/test_fairchem_legacy.py
  shell: /bin/bash -e {0}

...

/Users/runner/work/_temp/4ed94bd3-6523-4c6c-8f2c-4dfb2e7a598c.sh: line 3: hf: command not found
```

We last saw failures that looked like this when huggingface_hub changed the name of its cli to `hf` upon cutting its 1.0 release. It looks like something similar happened this time. On their [1.1.0 release](https://github.com/huggingface/huggingface_hub/releases/tag/v1.1.0), the CLI got split into a smaller standalone `hf` package. We could install the new CLI package in addition to huggingface_hub, but I don't think we even need to explicitly log in. The HF package knows to look for the HF_TOKEN env var, so in this PR I just drop the login line.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
