### PR TITLE
fix test sevennet

### DIFF
--- a/tests/models/test_sevennet.py
+++ b/tests/models/test_sevennet.py
@@ -34,8 +34,7 @@ def pretrained_sevenn_model():
     """Load a pretrained SevenNet model for testing."""
     cp = sevenn.util.load_checkpoint(model_name)
 
-    backend = "e3nn"
-    model_loaded = cp.build_model(backend)
+    model_loaded = cp.build_model()
     model_loaded.set_is_batch_data(True)
 
     return model_loaded.to(DEVICE)


### PR DESCRIPTION
## Summary

Fix #387 .

It changes only the test code. Original test code was using positional argument that is deprecated. As using default is all the same between the latest and old versions of SevenNet, the test code passes both sevennet 0.12.0 and below.

* Fix 1

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
