### PR TITLE
Better default force convergence function

### DIFF
--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -377,6 +377,22 @@ def test_optimize_fire(
     assert not torch.allclose(original_state.positions, final_state.positions)
 
 
+def test_force_convergence_fn_w_cell_filter(lj_model: LennardJonesModel):
+    """Tests that we can calculate static properties after an optimize run."""
+    atoms = bulk("Si", "diamond", a=5.43, cubic=True)
+    initial_state = ts.io.atoms_to_state(
+        atoms, device=lj_model.device, dtype=lj_model.dtype
+    )
+
+    ts.optimize(
+        system=initial_state,
+        model=lj_model,
+        optimizer=ts.Optimizer.fire,
+        convergence_fn=ts.generate_force_convergence_fn(),
+        max_steps=100,
+    )
+
+
 def test_default_converged_fn(
     ar_supercell_sim_state: SimState, lj_model: LennardJonesModel, tmp_path: Path
 ) -> None:

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -379,7 +379,7 @@ def _chunked_apply[T: SimState](
 
 
 def generate_force_convergence_fn[T: MDState | FireState](
-    force_tol: float = 1e-1, *, include_cell_forces: bool = True
+    force_tol: float = 1e-1, *, include_cell_forces: bool = False
 ) -> Callable:
     """Generate a force-based convergence function for the convergence_fn argument
     of the optimize function.
@@ -406,7 +406,7 @@ def generate_force_convergence_fn[T: MDState | FireState](
         """
         force_conv = ts.system_wise_max_force(state) < force_tol
 
-        if include_cell_forces and hasattr(state, "cell_forces"):
+        if include_cell_forces:
             if (cell_forces := getattr(state, "cell_forces", None)) is None:
                 raise ValueError("cell_forces not found in state")
             cell_forces_norm, _ = cell_forces.norm(dim=2).max(dim=1)


### PR DESCRIPTION
Make sure state has cell_forces attr so the default force convergence function works without and cell filter

## Summary

* This error bit me so I am fixing it.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
