### PR TITLE
Update energy description to 'Potential energy'

### DIFF
--- a/torch_sim/integrators/md.py
+++ b/torch_sim/integrators/md.py
@@ -28,7 +28,7 @@ class MDState(SimState):
         system_idx (torch.Tensor): System indices [n_particles]
         atomic_numbers (torch.Tensor): Atomic numbers [n_particles]
         momenta (torch.Tensor): Particle momenta [n_particles, n_dim]
-        energy (torch.Tensor): Total energy of the system [n_systems]
+        energy (torch.Tensor): Potential energy of the system [n_systems]
         forces (torch.Tensor): Forces on particles [n_particles, n_dim]
 
     Properties:


### PR DESCRIPTION
## Summary
This PR fixes the docstring comment for `MDState.energy` from total energy to (what I believe is correct) potential energy. For instance, in the trajectory reporter we use `state.energy` to report the potential energy: https://github.com/TorchSim/torch-sim/blob/main/torch_sim/runners.py#L40.


## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.
