### PR TITLE
Add close stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,21 @@
+name: 'Close Stale Pull Requests'
+
+on:
+  schedule:
+    # Run every day at midnight UTC
+    - cron: '0 0 * * *'
+
+jobs:
+  stale-pull-requests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: -1 # Disable issue staleness, only manage PRs
+          days-before-pr-stale: 35 # Days of inactivity before marking as stale
+          days-before-pr-close: 7 # Days of inactivity after 'stale' label before closing
+          stale-pr-message: 'This pull request has been marked as stale because it has been inactive for more than 5 weeks. Please update it or it will be automatically closed in 30 days.'
+          close-pr-message: 'This pull request has been automatically closed due to prolonged inactivity. Please reopen if you still intend to submit this PR.'
+          stale-pr-label: 'stale' # Label to apply when marking as stale
+          exempt-pr-labels: 'keep-open' # Labels that exempt a PR from being marked stale


### PR DESCRIPTION
PRs that have been made but then abandoned should be closed by a bot rather than by a person. This makes the process less biased. Maintainers can add the `keep-open` flag to keep PRs they are interested in from being closed by the bot.