### PR TITLE
memory_scales_with uses only use bbox if _is_rectangular_cell

### DIFF
--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -389,9 +389,8 @@ def _is_rectangular_cell(state: SimState, atol: float = 1e-6) -> bool:
     dot_01 = torch.dot(cell[0], cell[1])
     dot_02 = torch.dot(cell[0], cell[2])
     dot_12 = torch.dot(cell[1], cell[2])
-    return torch.allclose(
-        torch.stack([dot_01, dot_02, dot_12]), torch.zeros(3), atol=atol
-    )
+    dots = torch.stack([dot_01, dot_02, dot_12])
+    return torch.allclose(dots, torch.zeros_like(dots), atol=atol)
 
 
 def estimate_max_memory_scaler(


### PR DESCRIPTION
## Summary

- If we use bbox for non-rectangular cells, then we may incorrectly say that the volume is larger than it should be.
- So for non-rectangular cells we just use the determinant. This will offer the best volume estimation (especially because people only use a vacuum for rectangular cells)

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
