### PR TITLE
Bump pre-commit hooks and fix ruff lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,14 +7,14 @@ default_install_hook_types: [pre-commit, commit-msg]
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.15.0
     hooks:
       - id: ruff-check
         args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-case-conflict
       - id: check-symlinks
@@ -32,7 +32,7 @@ repos:
         stages: [pre-commit, commit-msg]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+    rev: v0.47.0
     hooks:
       - id: markdownlint
         # MD013: line length

--- a/examples/scripts/4_high_level_api.py
+++ b/examples/scripts/4_high_level_api.py
@@ -244,8 +244,9 @@ final_state = ts.optimize(
     system=systems,
     model=mace_model,
     optimizer=ts.Optimizer.fire,
-    convergence_fn=lambda state, last_energy: last_energy - state.energy
-    < 1e-6 * MetalUnits.energy,
+    convergence_fn=lambda state, last_energy: (
+        last_energy - state.energy < 1e-6 * MetalUnits.energy
+    ),
     max_steps=10 if SMOKE_TEST else 1000,
     init_kwargs=dict(cell_filter=ts.CellFilter.unit),
 )

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1000,13 +1000,13 @@ def test_truncate_trajectory(
             with pytest.raises(
                 ValueError,
                 match=(
-                    "Cannot truncate to a step greater than the last step. "
-                    "self.last_step=3 < step=10"
+                    r"Cannot truncate to a step greater than the last step\. "
+                    r"self\.last_step=3 < step=10"
                 ),
             ):
                 traj.truncate_to_step(10)
             with pytest.raises(
-                ValueError, match="Step must be larger than 0. Got step=0"
+                ValueError, match=r"Step must be larger than 0\. Got step=0"
             ):
                 traj.truncate_to_step(0)
 
@@ -1053,7 +1053,9 @@ def test_truncate_trajectory_reporter(
         ):
             trajectory_reporter.truncate_to_step(7)
         # try negative number
-        with pytest.raises(ValueError, match="Step must be greater than 0. Got step=-2"):
+        with pytest.raises(
+            ValueError, match=r"Step must be greater than 0\. Got step=-2"
+        ):
             trajectory_reporter.truncate_to_step(-2)
         # truncate to step 3
         trajectory_reporter.truncate_to_step(3)

--- a/torch_sim/models/lennard_jones.py
+++ b/torch_sim/models/lennard_jones.py
@@ -275,7 +275,7 @@ class LennardJonesModel(ModelInterface):
         )
 
         if self.use_neighbor_list:
-            mapping, system_mapping, shifts_idx = torchsim_nl(
+            mapping, _, shifts_idx = torchsim_nl(
                 positions=wrapped_positions,
                 cell=cell,
                 pbc=pbc,

--- a/torch_sim/models/morse.py
+++ b/torch_sim/models/morse.py
@@ -281,7 +281,7 @@ class MorseModel(ModelInterface):
         )
 
         if self.use_neighbor_list:
-            mapping, system_mapping, shifts_idx = torchsim_nl(
+            mapping, _, shifts_idx = torchsim_nl(
                 positions=wrapped_positions,
                 cell=cell,
                 pbc=pbc,

--- a/torch_sim/models/particle_life.py
+++ b/torch_sim/models/particle_life.py
@@ -164,7 +164,7 @@ class ParticleLifeModel(ModelInterface):
         )
 
         if self.use_neighbor_list:
-            mapping, system_mapping, shifts_idx = torchsim_nl(
+            mapping, _, shifts_idx = torchsim_nl(
                 positions=wrapped_positions,
                 cell=cell,
                 pbc=pbc,

--- a/torch_sim/models/soft_sphere.py
+++ b/torch_sim/models/soft_sphere.py
@@ -299,7 +299,7 @@ class SoftSphereModel(ModelInterface):
         )
 
         if self.use_neighbor_list:
-            mapping, system_mapping, shifts_idx = torchsim_nl(
+            mapping, _, shifts_idx = torchsim_nl(
                 positions=wrapped_positions,
                 cell=cell,
                 pbc=pbc,
@@ -727,7 +727,7 @@ class SoftSphereMultiModel(ModelInterface):
             system_idx = torch.zeros(
                 positions.shape[0], dtype=torch.long, device=self.device
             )
-            mapping, system_mapping, shifts_idx = torchsim_nl(
+            mapping, _, shifts_idx = torchsim_nl(
                 positions=positions,
                 cell=cell,
                 pbc=self.pbc,

--- a/torch_sim/optimizers/bfgs.py
+++ b/torch_sim/optimizers/bfgs.py
@@ -397,7 +397,7 @@ def bfgs_step(  # noqa: C901, PLR0915
         H = state.hessian[idx]  # [S_active, dim, dim]
 
         dp = dpos[idx].unsqueeze(2)  # [S_active, dim, 1]
-        df = dforces[idx].unsqueeze(2)  # [S_active, dim, 1] # noqa: PD901
+        df = dforces[idx].unsqueeze(2)  # [S_active, dim, 1]
 
         # a = dp^T @ df: [S_active, 1, dim] @ [S_active, dim, 1] -> [S_active, 1, 1]
         a = torch.bmm(dp.transpose(1, 2), df).squeeze(2)  # [S_active, 1]

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -48,7 +48,7 @@ def _configure_reporter(
             velocities=state.velocities, masses=state.masses
         ),
         "temperature": lambda state: state.calc_temperature(),
-        "max_force": lambda state: ts.system_wise_max_force(state),
+        "max_force": ts.system_wise_max_force,
     }
 
     prop_calculators = {

--- a/torch_sim/trajectory.py
+++ b/torch_sim/trajectory.py
@@ -255,9 +255,7 @@ class TrajectoryReporter:
                     # we partially evaluate the function to create a new function with
                     # an optional second argument, this can be set to state later on
                     new_fn = partial(
-                        lambda state, _=None, fn=None: (
-                            None if fn is None else fn(state)
-                        ),
+                        lambda state, _=None, fn=None: None if fn is None else fn(state),
                         fn=prop_fn,
                     )
                     self.prop_calculators[frequency][name] = new_fn
@@ -390,7 +388,7 @@ class TrajectoryReporter:
                     last_steps.append(traj.last_step)
         return last_steps
 
-    def __enter__(self) -> "TrajectoryReporter":
+    def __enter__(self) -> Self:
         """Support the context manager protocol.
 
         Returns:
@@ -1077,7 +1075,7 @@ class TorchSimTrajectory:
         if self._file.isopen:  # TODO: ???
             self._file.close()
 
-    def __enter__(self) -> "TorchSimTrajectory":
+    def __enter__(self) -> Self:
         """Support the context manager protocol.
 
         Returns:

--- a/torch_sim/transforms.py
+++ b/torch_sim/transforms.py
@@ -159,7 +159,7 @@ def pbc_wrap_batched(
     positions: torch.Tensor,
     cell: torch.Tensor,
     system_idx: torch.Tensor,
-    pbc: torch.Tensor | bool = True,  # noqa: FBT002
+    pbc: torch.Tensor | bool = True,  # noqa: FBT001, FBT002
 ) -> torch.Tensor:
     """Apply periodic boundary conditions to batched systems.
 

--- a/torch_sim/units.py
+++ b/torch_sim/units.py
@@ -7,6 +7,7 @@ Units are defined similar to https://docs.lammps.org/units.html.
 
 from enum import Enum
 from math import pi, sqrt
+from typing import Self
 
 
 class BaseConstant:
@@ -83,7 +84,7 @@ uc = UnitConversion
 class MetalUnits(float, Enum):
     """Metal unit system using Angstroms, eV, amu, and proton charge."""
 
-    def __new__(cls, value: float) -> "MetalUnits":
+    def __new__(cls, value: float) -> Self:
         """Create new MetalUnits enum value."""
         return float.__new__(cls, value)
 
@@ -106,7 +107,7 @@ class MetalUnits(float, Enum):
 class RealUnits(float, Enum):
     """Real unit system using Angstroms, kcal/mol, and proton charge."""
 
-    def __new__(cls, value: float) -> "RealUnits":
+    def __new__(cls, value: float) -> Self:
         """Create new RealUnits enum value."""
         return float.__new__(cls, value)
 

--- a/torch_sim/workflows/a2c.py
+++ b/torch_sim/workflows/a2c.py
@@ -196,16 +196,8 @@ def get_diameter_matrix(
                 diameter = float(elem1.metallic_radius + elem2.metallic_radius)
             else:
                 # For other pairs, sum atomic (preferred) or ionic radii
-                radius1 = float(
-                    elem1.atomic_radius
-                    if elem1.atomic_radius
-                    else elem1.average_ionic_radius
-                )
-                radius2 = float(
-                    elem2.atomic_radius
-                    if elem2.atomic_radius
-                    else elem2.average_ionic_radius
-                )
+                radius1 = float(elem1.atomic_radius or elem1.average_ionic_radius)
+                radius2 = float(elem2.atomic_radius or elem2.average_ionic_radius)
                 diameter = radius1 + radius2
 
             # Fill both symmetric positions in the matrix


### PR DESCRIPTION
## Summary

- Bump ruff v0.11.13 → v0.15.0, pre-commit-hooks v5 → v6, markdownlint-cli v0.45 → v0.47
- Fix 14 new ruff violations (RUF043, RUF059, PLW0108, PYI034, FBT001) across 12 files

Made with [Cursor](https://cursor.com)