### PR TITLE
Minor: enable MD progress bar

### DIFF
--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -27,6 +27,7 @@ from torch_sim.trajectory import TrajectoryReporter
 from torch_sim.typing import StateLike
 from torch_sim.units import UnitSystem
 
+
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Summary
Currently, `ts.integrate` only shows a progress bar when autobatching is enabled, and the progress bar is over the systems completed in the batch. This PR also adds a progress bar to the "inner" MD integration, which I find to be useful especially for longer-running MD. The default is to set `leave=False`, i.e., the inner progress bar disappears after it is complete, which avoids clogging the log for large batches where we have many inner MD loops.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.
