### PR TITLE
Hotfix: Max pin on tables due to broken 3.11 PyTables release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "h5py>=3.12.1",
     "nvalchemi-toolkit-ops>=0.2.0",
     "numpy>=1.26,<3",
-    "tables>=3.10.2",
+    "tables>=3.10.2,<3.11",
     "torch>=2",
     "tqdm>=4.67",
 ]


### PR DESCRIPTION
Tables release 3.11 now fails to install blosc2 which leads to issues in CI. 