### PR TITLE
Batched 3-body and 4-body

### DIFF
--- a/tests/test_nbody.py
+++ b/tests/test_nbody.py
@@ -358,9 +358,9 @@ def test_build_quadruplets_exact_torsion() -> None:
 
     result = build_quadruplets(main, qint, n_atoms, main_cell, qint_cell)
 
-    assert len(result["quad_main_edge_c_to_a"]) == 1
+    assert len(result["quad_c_to_a_edge"]) == 1
     # The single c→a edge is e5 (index 5), arriving at atom 2
-    assert result["quad_main_edge_c_to_a"][0].item() == 5
+    assert result["quad_c_to_a_edge"][0].item() == 5
     assert main[1, 5].item() == 2  # sanity: e5 targets atom 2
     # trip_in_to_quad[0] points into triplet_in["trip_in"]; d→b edge must target atom 1
     ti = build_mixed_triplets(
@@ -371,7 +371,7 @@ def test_build_quadruplets_exact_torsion() -> None:
         cell_offsets_in=main_cell,
         cell_offsets_out=qint_cell,
     )
-    d_to_b = ti["trip_in"][result["trip_in_to_quad"][0].item()]
+    d_to_b = ti["trip_in"][result["quad_d_to_b_trip_idx"][0].item()]
     assert main[1, d_to_b].item() == 1
 
 
@@ -411,8 +411,8 @@ def test_build_quadruplets_multi_input_triplets() -> None:
     # c≠d filter: c=src(e2)=5; d=src(e0)=0 → 5≠0 ✓; d=src(e1)=2 → 5≠2 ✓. All 2 survive.
     result = build_quadruplets(main, qint, n_atoms, main_cell, qint_cell)
 
-    assert len(result["quad_main_edge_c_to_a"]) == 2
-    assert (main[1][result["quad_main_edge_c_to_a"]] == 4).all()
+    assert len(result["quad_c_to_a_edge"]) == 2
+    assert (main[1][result["quad_c_to_a_edge"]] == 4).all()
     ti = build_mixed_triplets(
         main,
         qint,
@@ -421,25 +421,25 @@ def test_build_quadruplets_multi_input_triplets() -> None:
         cell_offsets_in=main_cell,
         cell_offsets_out=qint_cell,
     )
-    d_to_b = ti["trip_in"][result["trip_in_to_quad"]]
+    d_to_b = ti["trip_in"][result["quad_d_to_b_trip_idx"]]
     assert (main[1][d_to_b] == 1).all()
 
 
 def test_build_quadruplets_empty() -> None:
     """Disconnected main and qint graphs produce zero quadruplets."""
     main_edge_index = torch.tensor([[0], [1]])
-    qint_edge_index = torch.tensor([[2], [3]])
+    internal_edge_index = torch.tensor([[2], [3]])
     n_atoms = 4
     result = build_quadruplets(
         main_edge_index,
-        qint_edge_index,
+        internal_edge_index,
         n_atoms,
         torch.zeros(1, 3),
         torch.zeros(1, 3),
     )
-    assert len(result["quad_main_edge_c_to_a"]) == 0
-    assert len(result["trip_in_to_quad"]) == 0
-    assert len(result["trip_out_to_quad"]) == 0
+    assert len(result["quad_c_to_a_edge"]) == 0
+    assert len(result["quad_d_to_b_trip_idx"]) == 0
+    assert len(result["quad_c_to_a_trip_idx"]) == 0
 
 
 def test_build_quadruplets_cd_same_atom_different_cell() -> None:
@@ -467,7 +467,7 @@ def test_build_quadruplets_cd_same_atom_different_cell() -> None:
     qint_cell = torch.zeros(1, 3)
 
     result = build_quadruplets(main, qint, n_atoms, main_cell, qint_cell)
-    assert len(result["quad_main_edge_c_to_a"]) == 1
+    assert len(result["quad_c_to_a_edge"]) == 1
 
 
 @pytest.mark.parametrize(
@@ -493,20 +493,24 @@ def test_build_quadruplets_device(device: str) -> None:
     """Test that build_quadruplets works on different devices."""
     dev = torch.device(device)
     main_edge_index = torch.tensor([[0, 1, 1], [1, 2, 3]], device=dev)
-    qint_edge_index = torch.tensor([[1], [2]], device=dev)
+    internal_edge_index = torch.tensor([[1], [2]], device=dev)
     n_atoms = 4
 
     main_cell_offsets = torch.zeros(3, 3, device=dev)
-    qint_cell_offsets = torch.zeros(1, 3, device=dev)
+    internal_cell_offsets = torch.zeros(1, 3, device=dev)
 
     result = build_quadruplets(
-        main_edge_index, qint_edge_index, n_atoms, main_cell_offsets, qint_cell_offsets
+        main_edge_index,
+        internal_edge_index,
+        n_atoms,
+        main_cell_offsets,
+        internal_cell_offsets,
     )
 
-    assert result["quad_main_edge_c_to_a"].device == dev
-    assert result["trip_in_to_quad"].device == dev
-    assert result["main_edge_d_to_b"].device == dev
-    assert result["main_edge_c_to_a"].device == dev
+    assert result["quad_c_to_a_edge"].device == dev
+    assert result["quad_d_to_b_trip_idx"].device == dev
+    assert result["d_to_b_edge"].device == dev
+    assert result["c_to_a_edge"].device == dev
 
 
 def test_build_triplets_jit_script() -> None:
@@ -568,39 +572,47 @@ def test_build_mixed_triplets_jit_script() -> None:
 def test_build_quadruplets_jit_script() -> None:
     """Test that build_quadruplets can be JIT compiled."""
     main_edge_index = torch.tensor([[0, 2, 1, 1], [1, 1, 3, 4]])
-    qint_edge_index = torch.tensor([[1], [3]])
+    internal_edge_index = torch.tensor([[1], [3]])
     n_atoms = 5
     main_cell_offsets = torch.zeros(4, 3)
-    qint_cell_offsets = torch.zeros(1, 3)
+    internal_cell_offsets = torch.zeros(1, 3)
 
     compiled_fn = torch.jit.script(build_quadruplets)
 
     # Run compiled version
     result_compiled = compiled_fn(
-        main_edge_index, qint_edge_index, n_atoms, main_cell_offsets, qint_cell_offsets
+        main_edge_index,
+        internal_edge_index,
+        n_atoms,
+        main_cell_offsets,
+        internal_cell_offsets,
     )
 
     # Run original version
     result_original = build_quadruplets(
-        main_edge_index, qint_edge_index, n_atoms, main_cell_offsets, qint_cell_offsets
+        main_edge_index,
+        internal_edge_index,
+        n_atoms,
+        main_cell_offsets,
+        internal_cell_offsets,
     )
 
     # Results should match
     torch.testing.assert_close(
-        result_compiled["main_edge_d_to_b"], result_original["main_edge_d_to_b"]
+        result_compiled["d_to_b_edge"], result_original["d_to_b_edge"]
     )
     torch.testing.assert_close(
-        result_compiled["qint_edge_b_to_a"], result_original["qint_edge_b_to_a"]
+        result_compiled["b_to_a_edge"], result_original["b_to_a_edge"]
     )
     torch.testing.assert_close(
-        result_compiled["main_edge_c_to_a"], result_original["main_edge_c_to_a"]
+        result_compiled["c_to_a_edge"], result_original["c_to_a_edge"]
     )
     torch.testing.assert_close(
-        result_compiled["quad_main_edge_c_to_a"], result_original["quad_main_edge_c_to_a"]
+        result_compiled["quad_c_to_a_edge"], result_original["quad_c_to_a_edge"]
     )
     torch.testing.assert_close(
-        result_compiled["trip_in_to_quad"], result_original["trip_in_to_quad"]
+        result_compiled["quad_d_to_b_trip_idx"], result_original["quad_d_to_b_trip_idx"]
     )
     torch.testing.assert_close(
-        result_compiled["trip_out_to_quad"], result_original["trip_out_to_quad"]
+        result_compiled["quad_c_to_a_trip_idx"], result_original["quad_c_to_a_trip_idx"]
     )

--- a/torch_sim/neighbors/nbody.py
+++ b/torch_sim/neighbors/nbody.py
@@ -1,19 +1,36 @@
 """Pure-PyTorch triplet and quadruplet interaction index builders.
 
-All functions use only standard PyTorch ops (argsort, bincount, repeat_interleave,
-boolean masking, etc.) and are compatible with ``torch.jit.script``.
-No ``torch_scatter`` or ``torch_sparse`` dependencies.
+Uses only standard PyTorch ops (argsort, bincount, repeat_interleave, boolean
+masking) and is compatible with ``torch.jit.script``. No ``torch_scatter`` or
+``torch_sparse`` dependencies.
 
-Typical usage::
+``build_triplets`` finds every ordered pair of edges ``(b→a, c→a)`` sharing a
+target atom ``a`` — the angle environment used by three-body potentials (Tersoff,
+SW) and message-passing networks (DimeNet).
 
-    from torch_sim.neighbors import torchsim_nl
-    from torch_sim.neighbors.nbody import build_triplets, build_quadruplets
+``build_mixed_triplets`` does the same across two *different* edge sets (different
+cutoffs or connectivity rules). Used internally by ``build_quadruplets`` and
+directly for architectures with separate embedding and interaction graphs.
 
-    mapping, system_mapping, shifts_idx = torchsim_nl(
-        positions, cell, pbc, cutoff, system_idx
-    )
+``build_quadruplets`` builds four-body interactions ``d→b→a←c`` from two neighbour
+lists at different cutoffs. The *central* bond ``b→a`` comes from the "internal"
+graph (shorter cutoff), while the *outer* bonds ``d→b`` and ``c→a`` come from the
+**main** graph (longer cutoff)::
+
+    d ——(main, long)——> b ===(internal, short)===> a <——(main, long)—— c
+
+For each short central bond, all long-range neighbours of its endpoints are paired
+(excluding ``c == d`` in the same image). This biases the model toward interactions
+where the central bond is strongest, which is the opposite of a uniform-cutoff
+torsion. Pure-PyTorch equivalent of GemNet-OC ``get_quadruplets``::
+
+    mapping, _, shifts = torch_nl_linked_cell(pos, cell, pbc, tensor(5.0), sys_idx)
+    qmapping, _, qshifts = torch_nl_linked_cell(pos, cell, pbc, tensor(3.0), sys_idx)
     trip = build_triplets(mapping, n_atoms)
-    # trip["trip_in"], trip["trip_out"] index into edges
+    quad = build_quadruplets(mapping, qmapping, n_atoms, shifts.float(), qshifts.float())
+    # quad["quad_c_to_a_edge"]      — c→a main-edge index per quadruplet
+    # quad["quad_d_to_b_trip_idx"]  — index into d_to_b_edge/b_to_a_edge per quadruplet
+    # quad["quad_c_to_a_trip_idx"]  — index into c_to_a_edge per quadruplet
 """
 
 from __future__ import annotations
@@ -225,107 +242,105 @@ def build_mixed_triplets(
 
 def build_quadruplets(
     main_edge_index: torch.Tensor,
-    qint_edge_index: torch.Tensor,
+    internal_edge_index: torch.Tensor,
     n_atoms: int,
     main_cell_offsets: torch.Tensor,
-    qint_cell_offsets: torch.Tensor,
+    internal_cell_offsets: torch.Tensor,
 ) -> dict[str, torch.Tensor]:
     """Build quadruplet interaction indices ``d→b→a←c`` from two edge sets.
 
-    Combines an input triplet set ``d→b→a`` (edges from ``main_graph``
-    arriving at ``b`` for each ``qint_graph`` edge ``b→a``) with an output
-    triplet set ``c→a←b`` (``qint_graph`` edges arriving at ``a`` for each
-    ``main_graph`` edge ``c→a``), then takes their Cartesian product over the
-    shared intermediate edge ``b→a``.
+    For each internal (short-cutoff) bond ``b→a``, pairs every main-graph
+    neighbour ``d`` of ``b`` with every main-graph neighbour ``c`` of ``a``,
+    excluding ``c == d`` in the same periodic image.  The resulting four-atom
+    chains have a short central bond flanked by longer outer bonds::
+
+        d ——(main)——> b ===(internal)===> a <——(main)—— c
 
     Pure-PyTorch equivalent of GemNet-OC ``get_quadruplets``.
 
     Args:
-        main_edge_index: ``[2, n_main_edges]`` — main graph edges.
-        qint_edge_index: ``[2, n_qint_edges]`` — quadruplet interaction graph edges.
+        main_edge_index: ``[2, n_main]`` — long-range (outer) graph edges.
+        internal_edge_index: ``[2, n_internal]`` — short-range (central) graph edges.
         n_atoms: Total number of atoms.
-        main_cell_offsets: ``[n_main_edges, 3]`` cell offsets for main graph.
-        qint_cell_offsets: ``[n_qint_edges, 3]`` cell offsets for qint graph.
+        main_cell_offsets: ``[n_main, 3]`` periodic cell offsets for main graph.
+        internal_cell_offsets: ``[n_internal, 3]`` periodic cell offsets for
+            internal graph.
 
     Returns:
-        Dict with keys (for quadruplet ``d→b→a←c``):
+        Dict with keys describing the quadruplet ``d→b→a←c``:
 
-        - ``"main_edge_d_to_b"`` — main graph edge indices for ``d→b`` edges,
-          shape ``[n_trip_in]``. Indices into ``main_edge_index``.
-        - ``"qint_edge_b_to_a"`` — qint graph edge indices for ``b→a`` edges
-          (intermediate), shape ``[n_trip_in]``. Indices into ``qint_edge_index``.
-        - ``"qint_edge_b_to_a_agg"`` — aggregation indices for ``b→a`` edges,
+        - ``"d_to_b_edge"`` — main-edge indices for ``d→b``, shape ``[n_trip_in]``.
+        - ``"b_to_a_edge"`` — internal-edge indices for the central bond ``b→a``,
           shape ``[n_trip_in]``.
-        - ``"main_edge_c_to_a"`` — main graph edge indices for ``c→a`` edges,
-          shape ``[n_trip_out]``. Indices into ``main_edge_index``.
-        - ``"main_edge_c_to_a_agg"`` — aggregation indices for ``c→a`` edges,
+        - ``"b_to_a_edge_agg"`` — local aggregation index within each ``b→a`` edge,
+          shape ``[n_trip_in]``.
+        - ``"c_to_a_edge"`` — main-edge indices for ``c→a``, shape ``[n_trip_out]``.
+        - ``"c_to_a_edge_agg"`` — local aggregation index within each ``c→a`` edge,
           shape ``[n_trip_out]``.
-        - ``"quad_main_edge_c_to_a"`` — main graph edge indices for ``c→a`` edges
-          for each quadruplet, shape ``[n_quads]``. Indices into
-          ``main_edge_index``.
-        - ``"trip_in_to_quad"`` — maps input-triplet index → quadruplet index,
-          shape ``[n_quads]``.
-        - ``"trip_out_to_quad"`` — maps output-triplet index → quadruplet index,
-          shape ``[n_quads]``.
-        - ``"quad_main_edge_agg"`` — per-segment local index for aggregation,
-          shape ``[n_quads]``.
+        - ``"quad_c_to_a_edge"`` — main-edge index of the ``c→a`` bond for each
+          quadruplet, shape ``[n_quads]``.
+        - ``"quad_d_to_b_trip_idx"`` — index into ``d_to_b_edge`` / ``b_to_a_edge``
+          for each quadruplet, shape ``[n_quads]``.
+        - ``"quad_c_to_a_trip_idx"`` — index into ``c_to_a_edge`` for each
+          quadruplet, shape ``[n_quads]``.
+        - ``"quad_c_to_a_agg"`` — local aggregation index within each ``c→a`` main
+          edge across quadruplets, shape ``[n_quads]``.
     """
     src_main = main_edge_index[0]
     n_main_edges = src_main.size(0)
-    n_qint_edges = qint_edge_index.size(1)
+    n_internal_edges = internal_edge_index.size(1)
     device = src_main.device
 
-    # Input triplets: d→b→a  (input=main, output=qint, to_outedge=True)
+    # Input triplets d→b→a: main edges arriving at b, paired with internal edge b→a.
     triplet_in = build_mixed_triplets(
         main_edge_index,
-        qint_edge_index,
+        internal_edge_index,
         n_atoms,
         to_outedge=True,
         cell_offsets_in=main_cell_offsets,
-        cell_offsets_out=qint_cell_offsets,
+        cell_offsets_out=internal_cell_offsets,
     )
 
-    # Output triplets: c→a←b  (input=qint, output=main, to_outedge=False)
+    # Output triplets c→a←b: internal edge b→a paired with main edges arriving at a.
     triplet_out = build_mixed_triplets(
-        qint_edge_index,
+        internal_edge_index,
         main_edge_index,
         n_atoms,
         to_outedge=False,
-        cell_offsets_in=qint_cell_offsets,
+        cell_offsets_in=internal_cell_offsets,
         cell_offsets_out=main_cell_offsets,
     )
 
-    # Count input triplets per intermediate (qint) edge
+    # Count input triplets per internal edge
     ones_in = torch.ones_like(triplet_in["trip_out"])
-    n_trip_in_per_inter = torch.zeros(n_qint_edges, dtype=torch.long, device=device)
+    n_trip_in_per_inter = torch.zeros(n_internal_edges, dtype=torch.long, device=device)
     n_trip_in_per_inter.index_add_(0, triplet_in["trip_out"], ones_in)
 
-    # Build CSR of input triplets grouped by intermediate (qint) edge.
-    # Sort input triplets by qint edge so CSR lookup is contiguous.
+    # Build CSR of input triplets grouped by internal edge.
+    # Sort input triplets by internal edge so CSR lookup is contiguous.
     order_ti = torch.argsort(triplet_in["trip_out"], stable=True)
     sorted_trip_in_by_inter = triplet_in["trip_in"][order_ti]
 
-    csr_ti = torch.zeros(n_qint_edges + 1, dtype=torch.long, device=device)
+    csr_ti = torch.zeros(n_internal_edges + 1, dtype=torch.long, device=device)
     csr_ti[1:] = n_trip_in_per_inter.cumsum(0)
 
-    # For each output triplet, count how many input triplets share its intermediate edge.
-    # Only output triplets with ≥1 match can form quadruplets.
+    # Only output triplets with ≥1 matching input triplet can form quadruplets.
     n_in_for_out = n_trip_in_per_inter[triplet_out["trip_in"]]
     valid_out = n_in_for_out > 0
     trip_out_main = triplet_out["trip_out"][valid_out]  # c→a main edge indices
-    trip_out_inter = triplet_out["trip_in"][valid_out]  # b→a qint edge indices
+    trip_out_inter = triplet_out["trip_in"][valid_out]  # b→a internal edge indices
     n_in_for_valid = n_in_for_out[valid_out]
 
-    # Cartesian product: each valid output triplet paired with each of its input triplets.
-    quad_out = torch.repeat_interleave(trip_out_main, n_in_for_valid)
-    inter_edge = torch.repeat_interleave(trip_out_inter, n_in_for_valid)
-    trip_out_to_quad = torch.repeat_interleave(
+    # Cartesian product: each valid output triplet paired with each input triplet
+    # that shares its central b→a internal edge.
+    quad_c_to_a = torch.repeat_interleave(trip_out_main, n_in_for_valid)
+    central_edge = torch.repeat_interleave(trip_out_inter, n_in_for_valid)
+    quad_c_to_a_trip_idx = torch.repeat_interleave(
         torch.arange(trip_out_main.size(0), device=device), n_in_for_valid
     )
 
     # Local index cycling 0..n_in[e]-1 within each output-triplet block.
-    # cumsum gives the start of each block in the expanded array; subtracting it
-    # from the global position gives the within-block offset.
+    # cumsum gives the start of each block; subtracting it gives the within-block offset.
     n_quads_pre = int(n_in_for_valid.sum().item())
     cum_starts = torch.zeros(n_quads_pre, dtype=torch.long, device=device)
     if trip_out_main.size(0) > 0:
@@ -338,44 +353,31 @@ def build_quadruplets(
         cum_starts = torch.repeat_interleave(starts, n_in_for_valid)
     local = torch.arange(n_quads_pre, dtype=torch.long, device=device) - cum_starts
 
-    base = csr_ti[inter_edge]
-    ti_idx = base + local
-    d_to_b_edge = sorted_trip_in_by_inter[ti_idx]
+    ti_idx = csr_ti[central_edge] + local
+    d_to_b = sorted_trip_in_by_inter[ti_idx]
 
-    # Filter: c ≠ d (with cell offsets)
-    idx_atom_c = src_main[quad_out]
-    idx_atom_d = src_main[d_to_b_edge]
-
+    # Filter: c ≠ d (same atom in same periodic image is not a valid quadruplet)
     cell_offset_cd = (
-        main_cell_offsets[d_to_b_edge]
-        + qint_cell_offsets[inter_edge]
-        - main_cell_offsets[quad_out]
+        main_cell_offsets[d_to_b]
+        + internal_cell_offsets[central_edge]
+        - main_cell_offsets[quad_c_to_a]
     )
-    mask = (idx_atom_c != idx_atom_d) | torch.any(cell_offset_cd != 0, dim=-1)
+    mask = (src_main[quad_c_to_a] != src_main[d_to_b]) | torch.any(
+        cell_offset_cd != 0, dim=-1
+    )
 
-    quad_out = quad_out[mask]
-    trip_out_to_quad = trip_out_to_quad[mask]
-    trip_in_to_quad = order_ti[ti_idx[mask]]
-
-    quad_out_agg = _inner_idx(quad_out, n_main_edges)
+    quad_c_to_a = quad_c_to_a[mask]
+    quad_c_to_a_trip_idx = quad_c_to_a_trip_idx[mask]
+    quad_d_to_b_trip_idx = order_ti[ti_idx[mask]]
 
     return {
-        # d→b edge indices into main_edge_index
-        "main_edge_d_to_b": triplet_in["trip_in"],
-        # b→a edge indices into qint_edge_index (intermediate)
-        "qint_edge_b_to_a": triplet_in["trip_out"],
-        # aggregation index for b→a edges
-        "qint_edge_b_to_a_agg": triplet_in["trip_out_agg"],
-        # c→a edge indices into main_edge_index
-        "main_edge_c_to_a": triplet_out["trip_out"],
-        # aggregation index for c→a edges
-        "main_edge_c_to_a_agg": triplet_out["trip_out_agg"],
-        # c→a edge indices for each quadruplet
-        "quad_main_edge_c_to_a": quad_out,
-        # maps input-triplet index → quadruplet index
-        "trip_in_to_quad": trip_in_to_quad,
-        # maps output-triplet index → quadruplet index
-        "trip_out_to_quad": trip_out_to_quad,
-        # per-segment local index for aggregation
-        "quad_main_edge_agg": quad_out_agg,
+        "d_to_b_edge": triplet_in["trip_in"],
+        "b_to_a_edge": triplet_in["trip_out"],
+        "b_to_a_edge_agg": triplet_in["trip_out_agg"],
+        "c_to_a_edge": triplet_out["trip_out"],
+        "c_to_a_edge_agg": triplet_out["trip_out_agg"],
+        "quad_c_to_a_edge": quad_c_to_a,
+        "quad_d_to_b_trip_idx": quad_d_to_b_trip_idx,
+        "quad_c_to_a_trip_idx": quad_c_to_a_trip_idx,
+        "quad_c_to_a_agg": _inner_idx(quad_c_to_a, n_main_edges),
     }


### PR DESCRIPTION
This adds batched n-body searches which could be used to back classical models such as Stillinger-Weber and potentially torch-scatter independent implementations for things like GemNet.