### PR TITLE
Fix device mismatch in _split_state when splitting batched states with constraints

### DIFF
--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -883,7 +883,11 @@ def _split_state[T: SimState](state: T) -> list[T]:
             **global_attrs,
         }
 
-        atom_idx = torch.arange(cumsum_atoms[sys_idx], cumsum_atoms[sys_idx + 1])
+        atom_idx = torch.arange(
+            cumsum_atoms[sys_idx].item(),
+            cumsum_atoms[sys_idx + 1].item(),
+            device=state.device,
+        )
         new_constraints = [
             new_constraint
             for constraint in state.constraints


### PR DESCRIPTION
Fixes a RuntimeError when splitting batched SimState with FixAtoms constraints on CUDA. torch.arange() was creating atom_idx on CPU, causing a device mismatch in FixAtoms.select_sub_constraint() when torch.isin() was called.

Root cause: atom_idx = torch.arange(cumsum_atoms[sys_idx], cumsum_atoms[sys_idx + 1]) defaults to CPU.

Fix: Add device=state.device and use .item() for scalar bounds.

Affects v0.5.2 (and earlier). Upstream main already includes a similar fix in a larger refactor; this is a minimal backport for the v0.5.x line.