### PR TITLE
Add filtering of model tests based on file import closure

### DIFF
--- a/.github/scripts/__init__.py
+++ b/.github/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""GitHub workflow helper scripts."""

--- a/.github/scripts/check_model_affected.py
+++ b/.github/scripts/check_model_affected.py
@@ -1,0 +1,251 @@
+"""Check whether a single model test needs to run given the changed files.
+
+Combines internal repo import closure with external package scanning
+(the external package must already be installed in the current env).
+
+Exit codes:
+  0 — model is affected, run the tests
+  1 — model is NOT affected, skip the tests
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import shutil
+import subprocess
+import sys
+from collections import deque
+from pathlib import Path, PurePosixPath
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INTERNAL_PREFIXES = ("torch_sim/", "tests/")
+GLOBAL_TRIGGER_PATHS = {
+    ".github/scripts/check_model_affected.py",
+    ".github/workflows/model-tests.json",
+    ".github/workflows/test.yml",
+    "pyproject.toml",
+}
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--base", required=True)
+    parser.add_argument("--head", required=True)
+    parser.add_argument("--test-path", required=True)
+    parser.add_argument(
+        "--external-package",
+        default=None,
+        help="External package name to scan for torch_sim imports "
+        "(must already be installed).",
+    )
+    return parser.parse_args()
+
+
+def _relative_posix(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def _discover_python_files() -> set[str]:
+    python_files: set[str] = set()
+    for prefix in ("torch_sim", "tests"):
+        for path in (REPO_ROOT / prefix).rglob("*.py"):
+            python_files.add(_relative_posix(path))
+    return python_files
+
+
+def _module_name_for_path(path: str) -> str:
+    pure = PurePosixPath(path)
+    parts = list(pure.parts)
+    if pure.name == "__init__.py":
+        parts = parts[:-1]
+    else:
+        parts[-1] = pure.stem
+    return ".".join(parts)
+
+
+def _build_module_index(python_files: set[str]) -> dict[str, str]:
+    return {_module_name_for_path(p): p for p in python_files}
+
+
+def _current_package(module_name: str, path: str) -> str:
+    if PurePosixPath(path).name == "__init__.py":
+        return module_name
+    return module_name.rsplit(".", 1)[0]
+
+
+def _resolve_relative_module(
+    module_name: str | None, level: int, package_name: str
+) -> str | None:
+    if level == 0:
+        return module_name
+    package_parts = package_name.split(".")
+    ascents = level - 1
+    if ascents > len(package_parts):
+        return None
+    base_parts = package_parts[: len(package_parts) - ascents]
+    if module_name:
+        return ".".join([*base_parts, *module_name.split(".")])
+    return ".".join(base_parts)
+
+
+def _resolve_import_targets(path: str, module_index: dict[str, str]) -> set[str]:  # noqa: C901
+    source = (REPO_ROOT / path).read_text()
+    tree = ast.parse(source, filename=path)
+    module_name = _module_name_for_path(path)
+    package_name = _current_package(module_name, path)
+    targets: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                t = module_index.get(alias.name)
+                if t is not None:
+                    targets.add(t)
+        elif isinstance(node, ast.ImportFrom):
+            base = _resolve_relative_module(node.module, node.level, package_name)
+            if base is None:
+                continue
+            bt = module_index.get(base)
+            if bt is not None:
+                targets.add(bt)
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                cand = f"{base}.{alias.name}" if base else alias.name
+                t = module_index.get(cand)
+                if t is not None:
+                    targets.add(t)
+    return targets
+
+
+def _build_import_graph(
+    python_files: set[str], module_index: dict[str, str]
+) -> dict[str, set[str]]:
+    return {p: _resolve_import_targets(p, module_index) for p in python_files}
+
+
+def _pytest_conftest_paths(path: str) -> set[str]:
+    conftests: set[str] = set()
+    current = PurePosixPath(path).parent
+    while str(current) not in ("", "."):
+        candidate = current / "conftest.py"
+        if (REPO_ROOT / candidate).is_file():
+            conftests.add(candidate.as_posix())
+        current = current.parent
+    return conftests
+
+
+def _transitive_closure(graph: dict[str, set[str]], roots: set[str]) -> set[str]:
+    visited: set[str] = set()
+    queue = deque(roots)
+    while queue:
+        path = queue.popleft()
+        if path in visited:
+            continue
+        visited.add(path)
+        queue.extend(graph.get(path, ()))
+    return visited
+
+
+def _changed_files(base: str, head: str) -> set[str]:
+    git = shutil.which("git")
+    if git is None:
+        raise RuntimeError("git executable not found")
+    result = subprocess.run(  # noqa: S603
+        [git, "diff", "--name-only", base, head],
+        check=True,
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+    )
+    return {line for line in result.stdout.splitlines() if line}
+
+
+def _scan_external_package(package_name: str, module_index: dict[str, str]) -> set[str]:
+    """Scan an already-installed external package for torch_sim imports."""
+    spec = importlib.util.find_spec(package_name)
+    if spec is None or spec.origin is None:
+        return set()
+    origin = Path(spec.origin)
+    pkg_root = origin.parent if origin.name == "__init__.py" else origin.parent  # noqa: RUF034
+
+    repo_files: set[str] = set()
+    for py_file in pkg_root.rglob("*.py"):
+        try:
+            source = py_file.read_text(encoding="utf-8", errors="ignore")
+            tree = ast.parse(source)
+        except (SyntaxError, OSError):
+            continue
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name.startswith("torch_sim"):
+                        _resolve_module_to_file(alias.name, module_index, repo_files)
+            elif isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if mod.startswith("torch_sim"):
+                    _resolve_module_to_file(mod, module_index, repo_files)
+    return repo_files
+
+
+def _resolve_module_to_file(
+    module: str,
+    module_index: dict[str, str],
+    out: set[str],
+) -> None:
+    parts = module.split(".")
+    for i in range(len(parts), 0, -1):
+        candidate = ".".join(parts[:i])
+        if candidate in module_index:
+            out.add(module_index[candidate])
+            return
+
+
+def main() -> int:
+    """Exit 0 if the model is affected by changed files, 1 otherwise."""
+    args = _parse_args()
+    repo_changes = _changed_files(args.base, args.head)
+
+    if repo_changes & GLOBAL_TRIGGER_PATHS:
+        sys.stderr.write("Global trigger path changed — running tests\n")
+        return 0
+
+    internal_changes = {p for p in repo_changes if p.startswith(INTERNAL_PREFIXES)}
+    if not internal_changes:
+        sys.stderr.write("No internal changes — skipping tests\n")
+        return 1
+
+    python_files = _discover_python_files()
+    module_index = _build_module_index(python_files)
+
+    unknown = {
+        p for p in internal_changes if not p.endswith(".py") or p not in python_files
+    }
+    if unknown:
+        sys.stderr.write(f"Unclassifiable internal changes {unknown} — running tests\n")
+        return 0
+
+    graph = _build_import_graph(python_files, module_index)
+
+    roots = {args.test_path, *_pytest_conftest_paths(args.test_path)}
+
+    if args.external_package:
+        ext_files = _scan_external_package(args.external_package, module_index)
+        if ext_files:
+            sys.stderr.write(f"External deps on torch_sim: {sorted(ext_files)}\n")
+        roots.update(ext_files)
+
+    closure = _transitive_closure(graph, roots)
+    overlap = closure & internal_changes
+    if overlap:
+        sys.stderr.write(f"Affected files: {sorted(overlap)}\n")
+        return 0
+
+    sys.stderr.write("No affected files in closure — skipping tests\n")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/model-tests.json
+++ b/.github/workflows/model-tests.json
@@ -1,0 +1,13 @@
+[
+  {"name": "fairchem", "test_path": "tests/models/test_fairchem.py", "install_extra": "fairchem", "external_package": "fairchem"},
+  {"name": "fairchem-legacy", "test_path": "tests/models/test_fairchem_legacy.py", "install_extra": null, "external_package": null},
+  {"name": "graphpes", "test_path": "tests/models/test_graphpes_framework.py", "install_extra": "graphpes", "external_package": "graph_pes"},
+  {"name": "mace", "test_path": "tests/models/test_mace.py", "install_extra": "mace", "external_package": "mace"},
+  {"name": "mace", "test_path": "tests/test_elastic.py", "install_extra": "mace", "external_package": "mace"},
+  {"name": "mace", "test_path": "tests/test_optimizers_vs_ase.py", "install_extra": "mace", "external_package": "mace"},
+  {"name": "mattersim", "test_path": "tests/models/test_mattersim.py", "install_extra": "mattersim", "external_package": "mattersim"},
+  {"name": "metatomic", "test_path": "tests/models/test_metatomic.py", "install_extra": "metatomic", "external_package": "metatomic"},
+  {"name": "nequip", "test_path": "tests/models/test_nequip_framework.py", "install_extra": "nequip", "external_package": "nequip"},
+  {"name": "orb", "test_path": "tests/models/test_orb.py", "install_extra": "orb", "external_package": "orb_models"},
+  {"name": "sevenn", "test_path": "tests/models/test_sevennet.py", "install_extra": "sevenn", "external_package": "sevenn"}
+]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,34 +60,36 @@ jobs:
           - { python: '3.12', resolution: lowest-direct }
           - { python: '3.14', resolution: highest }
         model:
-          - { name: fairchem, test_path: "tests/models/test_fairchem.py" }
-          - { name: fairchem-legacy, test_path: "tests/models/test_fairchem_legacy.py" }
-          - { name: graphpes, test_path: "tests/models/test_graphpes_framework.py" }
-          - { name: mace, test_path: "tests/models/test_mace.py" }
-          - { name: mace, test_path: "tests/test_elastic.py" }
-          - { name: mace, test_path: "tests/test_optimizers_vs_ase.py" }
-          - { name: mattersim, test_path: "tests/models/test_mattersim.py" }
-          - { name: metatomic, test_path: "tests/models/test_metatomic.py" }
-          - { name: nequip, test_path: "tests/models/test_nequip_framework.py" }
-          - { name: orb, test_path: "tests/models/test_orb.py" }
-          - { name: sevenn, test_path: "tests/models/test_sevennet.py" }
+          - { name: fairchem, test_path: 'tests/models/test_fairchem.py', external_package: fairchem }
+          - { name: fairchem-legacy, test_path: 'tests/models/test_fairchem_legacy.py', external_package: '' }
+          - { name: graphpes, test_path: 'tests/models/test_graphpes_framework.py', external_package: graph_pes }
+          - { name: mace, test_path: 'tests/models/test_mace.py', external_package: mace }
+          - { name: mace, test_path: 'tests/test_elastic.py', external_package: mace }
+          - { name: mace, test_path: 'tests/test_optimizers_vs_ase.py', external_package: mace }
+          - { name: mattersim, test_path: 'tests/models/test_mattersim.py', external_package: mattersim }
+          - { name: metatomic, test_path: 'tests/models/test_metatomic.py', external_package: metatomic }
+          - { name: nequip, test_path: 'tests/models/test_nequip_framework.py', external_package: nequip }
+          - { name: orb, test_path: 'tests/models/test_orb.py', external_package: orb_models }
+          - { name: sevenn, test_path: 'tests/models/test_sevennet.py', external_package: sevenn }
         exclude:
           - version: { python: '3.14', resolution: highest }
-            model: { name: orb, test_path: 'tests/models/test_orb.py' }
+            model: { name: orb, test_path: 'tests/models/test_orb.py', external_package: orb_models }
           - version: { python: '3.14', resolution: highest }
-            model: { name: fairchem, test_path: 'tests/models/test_fairchem.py'}
+            model: { name: fairchem, test_path: 'tests/models/test_fairchem.py', external_package: fairchem }
           - version: { python: '3.14', resolution: highest }
-            model: { name: fairchem-legacy, test_path: 'tests/models/test_fairchem_legacy.py'}
+            model: { name: fairchem-legacy, test_path: 'tests/models/test_fairchem_legacy.py', external_package: '' }
           - version: { python: '3.14', resolution: highest }
-            model: { name: nequip, test_path: 'tests/models/test_nequip_framework.py'}
+            model: { name: nequip, test_path: 'tests/models/test_nequip_framework.py', external_package: nequip }
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Check out repo
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Check out fairchem repository
-        if: ${{ matrix.model.name == 'fairchem-legacy' }}
+        if: matrix.model.name == 'fairchem-legacy'
         uses: actions/checkout@v4
         with:
           repository: FAIR-Chem/fairchem
@@ -107,7 +109,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
 
       - name: Install legacy fairchem repository and dependencies
-        if: ${{ matrix.model.name == 'fairchem-legacy' }}
+        if: matrix.model.name == 'fairchem-legacy'
         run: |
           if [ -f fairchem-repo/packages/requirements.txt ]; then
             uv pip install -r fairchem-repo/packages/requirements.txt --system
@@ -121,14 +123,32 @@ jobs:
           uv pip install "ase>=3.26" "phonopy>=2.37.0" "psutil>=7.0.0" "pymatgen>=2025.6.14" "pytest-cov>=6" "pytest>=8" --resolution=${{ matrix.version.resolution }} --system
 
       - name: Install torch_sim with model dependencies
-        if: ${{ matrix.model.name != 'fairchem-legacy' }}
+        if: matrix.model.name != 'fairchem-legacy'
         run: |
-          # setuptools <82 provides pkg_resources needed by mattersim and fairchem (via torchtnt).
-          # setuptools 82+ removed pkg_resources. Remove pin once those packages migrate.
           uv pip install -e ".[test,${{ matrix.model.name }}]" "setuptools>=70,<82" --resolution=${{ matrix.version.resolution }} --system
 
+      - name: Check if model is affected by changes
+        id: check_affected
+        if: github.event_name == 'pull_request'
+        run: |
+          args=(
+            --base "${{ github.event.pull_request.base.sha }}"
+            --head "${{ github.sha }}"
+            --test-path "${{ matrix.model.test_path }}"
+          )
+          if [ -n "${{ matrix.model.external_package }}" ]; then
+            args+=(--external-package "${{ matrix.model.external_package }}")
+          fi
+          if python .github/scripts/check_model_affected.py "${args[@]}"; then
+            echo "affected=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "affected=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run ${{ matrix.model.test_path }} tests
-        if: ${{ !contains(matrix.model.name, 'fairchem') || github.event.pull_request.head.repo.fork == false }}
+        if: >-
+          (github.event_name != 'pull_request' || steps.check_affected.outputs.affected == 'true')
+          && (!contains(matrix.model.name, 'fairchem') || github.event.pull_request.head.repo.fork == false)
         env:
           HF_TOKEN: ${{ secrets.HUGGING_FACE_TOKEN }}
         run: |
@@ -138,6 +158,9 @@ jobs:
           pytest -vv -ra -rs --cov=torch_sim --cov-report=xml ${{ matrix.model.test_path }}
 
       - name: Upload coverage to Codecov
+        if: >-
+          (github.event_name != 'pull_request' || steps.check_affected.outputs.affected == 'true')
+          && (!contains(matrix.model.name, 'fairchem') || github.event.pull_request.head.repo.fork == false)
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/docs/dev/add_model.md
+++ b/docs/dev/add_model.md
@@ -1,36 +1,20 @@
 # Adding New Models
 
-## How to add a new model to TorchSim
+We welcome new model integrations into the TorchSim ecosystem. Our preferred pattern is that developers implement the bulk of the TorchSim integration in their own model repository or package, and then TorchSim provides a thin wrapper or re-export for convenience. This keeps the model-specific logic close to the model itself while still making the integration easy to discover from `torch_sim.models`.
 
-We welcome the addition of new models to `torch_sim`. We want
-easy batched simulations to be available to the whole community
-of MLIP developers and users.
+If you want TorchSim to expose your model, the recommended steps are:
 
-1. Open a PR or an issue to get feedback. We are happy to take a look,
-even if you haven't finished your implementation yet.
+1. Open a PR or issue early. We are happy to review incomplete work and discuss the best integration shape.
+2. Prefer implementing the real integration in the upstream model package. The TorchSim-side file in `torch_sim/models` should ideally be a small wrapper or re-export, similar to other external integrations.
+3. If some logic must live in TorchSim, keep it minimal and well-contained. The implementation should still follow the `torch_sim.models.interface.ModelInterface` contract.
+4. Add model tests using `make_validate_model_outputs_test` and, where appropriate, `make_model_calculator_consistency_test`. See the existing model tests for examples.
+5. Update `.github/workflows/test.yml` and `.github/workflows/model-tests.json` so the model installs and tests correctly in CI.
+6. Re-export the model from `torch_sim.models.__init__.py` using the existing `try`/`except ImportError` pattern.
+7. Update `docs/conf.py` so the docs can build without requiring the optional model dependency.
 
-1. Create a new model file in `torch_sim/models`. It should inherit
-from `torch_sim.models.interface.ModelInterface` and `torch.nn.module`.
+Optional follow-up work:
 
-1. Add `torch_sim.models.tests.make_validate_model_outputs_test` and
-`torch_sim.models.tests.make_model_calculator_consistency_test` as
-models tests. See any of the other model tests for examples.
+1. Add a tutorial or example showing how to use the model with TorchSim.
+2. Update `.github/workflows/docs.yml` if the documentation build needs to exercise that integration.
 
-1. Update `test.yml` to include proper installation and
-testing of the relevant model.
-
-1. Pull the model import up to `torch_sim.models` by adding import to
-`torch_sim.models.__init__.py` in try except clause.
-
-1. Update `docs/conf.py` to include model in `autodoc_mock_imports = [...]`
-
-## Optional
-
-1. Write a tutorial or example showing off your model.
-
-1. Update the `.github/workflows/docs.yml` to ensure your model
-is being correctly included in the documentation.
-
-We are also happy for developers to implement model interfaces in their
-own codebases. Steps 1 & 2 should still be followed to ensure the model
-implementation is compatible with the rest of TorchSim.
+We are also happy for developers to keep the entire integration in their own repository without adding a wrapper in TorchSim. But when TorchSim does expose a model, we prefer the bulk of the logic to live upstream and the TorchSim wrapper to stay thin.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ isort.lines-after-imports = 2
 pep8-naming.ignore-names = ["get_kT", "kT"]
 
 [tool.ruff.lint.per-file-ignores]
+".github/scripts/*.py" = ["INP001"]
 "**/tests/*" = ["ANN201", "D", "INP001", "S101"]
 "examples/**/*" = ["B018", "T201"]
 "examples/tutorials/**/*" = ["ALL"]


### PR DESCRIPTION
This should mean that we only test models which have been affected by file changes wrt main. 

Actually this is insufficient with external posture as it doesn't check the external torchsim closure. 