### PR TITLE
Phonopy removed dummy pbc kwarg in 3.2.0 breaking test fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,6 @@ def si_phonopy_atoms() -> Any:
         cell=lattice,
         scaled_positions=coords,
         symbols=species,
-        pbc=True,
     )
 
 


### PR DESCRIPTION
See title. The arg was already defunct in the io but was used in the test setup.