### PR TITLE
Remove unnecessary stress evaluation in NPTLangevin

### DIFF
--- a/torch_sim/integrators/npt.py
+++ b/torch_sim/integrators/npt.py
@@ -704,11 +704,6 @@ def npt_langevin_step(
     n_atoms_per_system = torch.bincount(state.system_idx)
     state.cell_masses = (n_atoms_per_system + 1) * batch_kT * torch.square(state.b_tau)
 
-    # Compute model output for current state
-    model_output = model(state)
-    state.forces = model_output["forces"]
-    state.stress = model_output["stress"]
-
     # Store initial values for integration
     forces = state.forces
     F_p_n = _compute_cell_force(


### PR DESCRIPTION
## Summary

Needed before stress was added to NPTState.
I've checked manually that the `model_output["stress"]` and `state.stress` were identical.
Also JAXMD only runs one evaluation

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
