### PR TITLE
split instead or sequential getitem (slicing under the hood)

### DIFF
--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -794,9 +794,8 @@ class BinningAutoBatcher[T: SimState]:
             ordered_results = batcher.restore_original_order(results)
 
         """
-        all_states = [
-            state[i] for state in batched_states for i in range(state.n_systems)
-        ]
+        all_states = [state.split() for state in batched_states]
+        all_states = list(chain.from_iterable(all_states))
         original_indices = list(chain.from_iterable(self.index_bins))
 
         if len(all_states) != len(original_indices):


### PR DESCRIPTION
## Summary

Small change to improve speed. `__getitem__` makes a lot of slicing and reindexing.
In normal setting, there is a 3x factor difference for overall, low duration, so that's fine anyway.

Interestingly, it combines super poorly with FixSymmery, script at the end:
On cpu: for 100 systems 
CustomAutoBatcher duration: 0.0091 seconds
Original BinningAutoBatcher duration: 6.1686 seconds 
On gpu:
CustomAutoBatcher duration: 0.0409 seconds
Original BinningAutoBatcher duration: 0.9110 seconds 

I'm currently investigating FixSymmetry as the slicing is super costly.

```
from torch_sim.autobatching import BinningAutoBatcher
from itertools import chain
from typing import Sequence, TypeVar
import torch_sim as ts
from torch_sim.optimizers import OPTIM_REGISTRY
import warnings
warnings.filterwarnings("ignore", category=UserWarning)

T = TypeVar('T')

# inherits to modify restore_original_order

class CustomAutoBatcher(BinningAutoBatcher):
    def restore_original_order(self, batched_states: Sequence[T]) -> list[T]:
        # results is a list of lists of results for each batch
        # we need to flatten it and then reorder it according to original_indices
        all_states = [state.split() for state in batched_states]
        all_states = list(chain.from_iterable(all_states))
        original_indices = list(chain.from_iterable(self.index_bins))

        if len(all_states) != len(original_indices):
            raise ValueError(
                f"Number of states ({len(all_states)}) does not match "
                f"number of original indices ({len(original_indices)})"
            )

        # sort states by original indices
        indexed_states = list(zip(original_indices, all_states, strict=True))
        return [state for _, state in sorted(indexed_states, key=lambda x: x[0])]
    

from ase.build import bulk

def speed_auto_batching(autobatcher: CustomAutoBatcher):
  import torch
  import numpy as np

  torch_dtype = torch.float32
  device = "cuda" if torch.cuda.is_available() else "cpu"
  # device = "cpu"
  print(device)

  init_fn, step_fn = OPTIM_REGISTRY["bfgs"]


  structure = bulk("Al", "fcc", a=4.05, cubic=True)
  structures = [structure * np.random.randint(1, 3) for _ in range(100)]
  print(len(structures), "structures created")
  # structures[0] = structure * (3, 3, 3)
  initial_state = ts.initialize_state(structures, device=device, dtype=torch_dtype)

  initial_state.constraints = ts.constraints.FixSymmetry.from_state(
      initial_state, symprec=0.1
    )

  autobatcher.load_states(initial_state)
  initialized = [
    batch for batch, _indices in autobatcher
  ]
  print("Number of batches:", len(initialized))
  start = time.time()
  for _ in range(1):
    # step_fn should be called with the original order of states, not the batched order
    _ = autobatcher.restore_original_order(initialized)
  end = time.time()
  return end - start

original_autobatcher = BinningAutoBatcher(
  model=None,
  max_memory_scaler=10_000,
  memory_scales_with="n_atoms"
)

autobatcher = CustomAutoBatcher(
  model=None,
  max_memory_scaler=10_000,
  memory_scales_with="n_atoms"
)

import time

duration = speed_auto_batching(autobatcher)
original_duration = speed_auto_batching(original_autobatcher)
print(f"CustomAutoBatcher duration: {duration:.4f} seconds")
print(f"Original BinningAutoBatcher duration: {original_duration:.4f} seconds ")
```

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [X] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
