### PR TITLE
docs(optimize): document post-hoc convergence check

### DIFF
--- a/examples/tutorials/high_level_tutorial.py
+++ b/examples/tutorials/high_level_tutorial.py
@@ -347,6 +347,10 @@ that instead of taking `n_steps` and `temperature`, `optimize` takes a `converge
 that determines when the optimization is converged. By default, the `convergence_fn` will
 wait until the energy difference between steps is less than 1 meV.
 
+Note that `optimize` returns the final state even if `max_steps` is reached before
+convergence. To check per-system convergence afterwards, evaluate
+`convergence_fn(final_state)` on the returned state.
+
 Let's use the `optimize` function with the FIRE algorithm to relax our structures:
 """
 
@@ -359,6 +363,8 @@ final_state = ts.optimize(
 )
 
 final_atoms = final_state.to_atoms()
+# `optimize` may return `final_atoms` before convergence if `max_steps` is reached.
+# Evaluate `convergence_fn` on `final_state` to verify per-system convergence
 
 
 # %% [markdown]
@@ -408,6 +414,10 @@ final_state = ts.optimize(
 )
 
 final_atoms = final_state.to_atoms()
+
+# Check per-system convergence on the returned state
+convergence_tensor = force_convergence_fn(final_state)
+print(f"Converged systems: {convergence_tensor.tolist()}")
 
 
 # %% [markdown]

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -593,6 +593,11 @@ def optimize[T: OptimState](  # noqa: C901, PLR0915
 
     Returns:
         T: Optimized system state
+
+    Notes:
+        The state is returned even if max_steps was reached before
+        `convergence_fn` was satisfied. To check per-system convergence,
+        evaluate `convergence_fn(final_state)` on the returned state
     """
     # create a default convergence function if one is not provided
     # TODO: document this behavior


### PR DESCRIPTION
## Summary
Closes https://github.com/TorchSim/torch-sim/issues/542 with the docs-only approach as suggested.

* Added a Notes section to the `optimize` docstring describing the behavior where `final_state` is returned even when `max_steps` is reached, and documented the post-hoc check
* Mirrored the same explanation in the high-level tutorial's Geometry Optimization section

I also checked that the documents are properly rendered locally.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.