### PR TITLE
Detach state tensors after each step to prevent computation graph buildup

### DIFF
--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -383,6 +383,9 @@ def integrate[T: SimState](  # noqa: C901
                 **integrator_kwargs,
             )
 
+            if not getattr(model, "retain_graph", False):
+                state.detach_()
+
             if trajectory_reporter:
                 trajectory_reporter.report(state, step, model=model)
 
@@ -696,6 +699,9 @@ def optimize[T: OptimState](  # noqa: C901, PLR0915
             if hasattr(state, "energy"):
                 last_energy = state.energy
             state = step_fn(state=state, model=model, **optimizer_kwargs)
+
+            if not getattr(model, "retain_graph", False):
+                state.detach_()
 
             if trajectory_reporter:
                 trajectory_reporter.report(

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -409,7 +409,7 @@ class SimState:
         This severs the autograd graph that accumulates when model forward passes
         produce graph-attached tensors (energy, forces, stress) stored on the state.
         Without detaching, each simulation step builds an ever-growing computation
-        graph chain, causing progressive slowdown and memory growth.
+        graph chain, causing progressive slowdown.
 
         Uses ``object.__setattr__`` to bypass ``SimState.__setattr__`` coercion
         and avoid re-validating ``system_idx`` on every call.

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -403,6 +403,32 @@ class SimState:
             elif leading == n_systems:
                 self._system_extras[key] = val
 
+    def detach_(self) -> Self:
+        """Detach all tensor fields and extras from the computation graph in-place.
+
+        This severs the autograd graph that accumulates when model forward passes
+        produce graph-attached tensors (energy, forces, stress) stored on the state.
+        Without detaching, each simulation step builds an ever-growing computation
+        graph chain, causing progressive slowdown and memory growth.
+
+        Uses ``object.__setattr__`` to bypass ``SimState.__setattr__`` coercion
+        and avoid re-validating ``system_idx`` on every call.
+
+        Returns:
+            Self: The same state instance, for method chaining.
+        """
+        for f in fields(self):
+            val = getattr(self, f.name)
+            if isinstance(val, torch.Tensor):
+                object.__setattr__(self, f.name, val.detach())
+        for key, val in self._atom_extras.items():
+            if isinstance(val, torch.Tensor):
+                self._atom_extras[key] = val.detach()
+        for key, val in self._system_extras.items():
+            if isinstance(val, torch.Tensor):
+                self._system_extras[key] = val.detach()
+        return self
+
     @property
     def wrap_positions(self) -> torch.Tensor:
         """Atomic positions wrapped according to periodic boundary conditions if pbc=True,


### PR DESCRIPTION
## Summary
- Add `SimState.detach_()` method that detaches all tensor fields and extras from the computation graph in-place
- Call `state.detach_()` after each step in `integrate()` and `optimize()` loops, gated on `model.retain_graph`
- Prevents progressive slowdown in long MD optimization runs

## Test plan
- [x] All core tests pass (runners, optimizers, integrators, autobatching, state)
- [x] Run 100k-step MD to confirm slowdown is resolved with detach fix
<img width="1586" height="543" alt="Detach_vs_no-detach" src="https://github.com/user-attachments/assets/f500fd36-65df-4799-8e21-d7b573f48171" />
The spike around step 70k probably came from the HPC system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)