### PR TITLE
Pin torch version due to 3.14 compile issues

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,10 @@ dependencies = [
     "h5py>=3.15.1",
     "numpy>=1.26,<3; python_version < '3.13'",
     "numpy>=2.3.2,<3; python_version >= '3.13'",
-    "nvalchemi-toolkit-ops[torch]>=0.3.0",
+    "nvalchemi-toolkit-ops[torch]>=0.3.1",
     "tables>=3.11.1",
-    "torch>=2",
+    "torch>=2; python_version < '3.14'",
+    "torch>=2.11; python_version >= '3.14'",
     "tqdm>=4.67",
 ]
 


### PR DESCRIPTION
These issues were surfaced in an alchemiops error for highest deps. They are no longer apparent in the resolved pattern afaict but perhaps worth guarding.