### PR TITLE
Fix wrong default value in doc-string

### DIFF
--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -491,7 +491,7 @@ def generate_force_convergence_fn[T: MDState | FireState](
     Args:
         force_tol (float): Force tolerance for convergence
         include_cell_forces (bool): Whether to include the `cell_forces` in
-            the convergence check. Defaults to True.
+            the convergence check. Defaults to False.
 
     Returns:
         Convergence function that takes a state and last energy and


### PR DESCRIPTION
Nothing fancy, but I finally got back to using `torch-sim` and noticed this small mismatch in the doc-string, which was introduced when the default value was updated in #404