### PR TITLE
fix(neighbors): zero dummy cell for non-periodic systems in alchemiops naive NL

### DIFF
--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -286,11 +286,13 @@ def test_neighbor_list_invariant_under_lattice_image_shifts(
     _nl_backends_x_cutoffs(),
 )
 @pytest.mark.parametrize("self_interaction", [True, False])
+@pytest.mark.parametrize("molecule_dummy_cell", [0.0, 1.0])
 def test_neighbor_list_implementations(
     *,
     nl_implementation: Callable[..., tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
     cutoff: float,
     self_interaction: bool,
+    molecule_dummy_cell: float,
     molecule_atoms_set: list[Atoms],
     periodic_atoms_set: list[Atoms],
 ) -> None:
@@ -298,8 +300,17 @@ def test_neighbor_list_implementations(
 
     Tests all implementations in batched mode with mixed periodic and non-periodic
     systems, comparing sorted distances against ASE reference values.
+
+    With molecule_dummy_cell != 0 the non-periodic molecules carry a non-zero
+    (dummy) cell, e.g. from ase.Atoms.get_cell(complete=True). Since pbc stays False
+    the neighbor list must remain cell-independent and still match ASE values.
     """
-    atoms_list = molecule_atoms_set + periodic_atoms_set
+    molecules = molecule_atoms_set
+    if molecule_dummy_cell:
+        molecules = [atoms.copy() for atoms in molecule_atoms_set]
+        for atoms in molecules:
+            atoms.set_cell([molecule_dummy_cell] * 3)  # dummy cell; pbc stays False
+    atoms_list = molecules + periodic_atoms_set
     is_alchemiops = "alchemiops" in nl_implementation.__name__
     if is_alchemiops and cutoff >= 3:
         atoms_list = [a for a in atoms_list if not a.info.get("very_skewed")]

--- a/torch_sim/neighbors/alchemiops.py
+++ b/torch_sim/neighbors/alchemiops.py
@@ -71,6 +71,17 @@ if ALCHEMIOPS_AVAILABLE:
 
         if _batch_naive_neighbor_list is None:
             raise RuntimeError("nvalchemiops neighbor list is unavailable")
+
+        # Temporary fix: the naive kernel wraps on every axis ignoring pbc, so a
+        # non-zero cell breaks non-periodic and partial-pbc systems. Zeroing the cell
+        # makes the wrap a no-op, fixing fully non-periodic systems (e.g. molecules).
+        # Slabs / partial pbc are not covered yet and need the upstream fix.
+        # See https://github.com/TorchSim/torch-sim/issues/575
+        non_periodic = ~pbc.any(dim=1)  # [n_systems]
+        if non_periodic.any():
+            cell = cell.clone()  # avoid modifying the original
+            cell[non_periodic] = 0.0
+
         res = _batch_naive_neighbor_list(
             positions=positions,
             cutoff=cutoff,


### PR DESCRIPTION
## Summary
Related to https://github.com/TorchSim/torch-sim/issues/575.

## Fix
The alchemiops naive backend returns a wrong neighbor list for non-periodic systems carrying a non-zero (dummy) cell, because the kernel wraps on every axis ignoring pbc.

## Test
Extended `test_neighbor_list_implementations` with a `molecule_dummy_cell` axis: non-periodic molecules carrying a dummy cell must still match the ASE reference across all backends.
Confirmed that newly added tests fail without this patch.

## Note
Slabs / partial pbc (e.g. `[T, T, F]`) are not covered and still need the upstream fix (NVIDIA/nvalchemi-toolkit-ops#104).
So, even after this PR is merged, we cannot close the above issue, but this PR would resolve the major path where molecule is called with dummy cell.

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [x] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
