### PR TITLE
check for disordered structure

### DIFF
--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -172,6 +172,22 @@ def test_state_round_trip(
         assert torch.allclose(sim_state.masses, round_trip_state.masses)
 
 
+def test_structures_to_state_disordered() -> None:
+    """structures_to_state rejects disordered (partial occupancy) structures."""
+    pytest.importorskip("pymatgen")
+    from pymatgen.core import Lattice, Structure
+
+    # Site with partial occupancy (Cu/Au solid solution) -> disordered
+    disordered = Structure(
+        Lattice.cubic(3.6),
+        [{"Cu": 0.5, "Au": 0.5}],
+        [[0.0, 0.0, 0.0]],
+    )
+    assert not disordered.is_ordered
+    with pytest.raises(ValueError, match="Disordered structures are not supported"):
+        ts.io.structures_to_state(disordered, DEVICE, DTYPE)
+
+
 @pytest.mark.parametrize(
     ("monkeypatch_modules", "func", "args", "match"),
     [

--- a/torch_sim/io.py
+++ b/torch_sim/io.py
@@ -394,6 +394,11 @@ def structures_to_state(
 
     struct_list = [structure] if isinstance(structure, Structure) else structure
 
+    # Check that structures are not disordered
+    for s in struct_list:
+        if not s.is_ordered:
+            raise ValueError("Disordered structures are not supported")
+
     # Stack all properties
     cell = torch.tensor(
         np.stack([s.lattice.matrix.T for s in struct_list]), dtype=dtype, device=device


### PR DESCRIPTION
## Summary

Added a check and error if an input pymatgen structure is disordered.
Context is that otherwise the reported error when providing a structure with site defects is quite unclear.

"torch_sim/io.py", line 367, in structures_to_state
    np.concatenate([[site.specie.atomic_mass for site in s] for s in struct_list]),
AttributeError: attr='specie' not found on PeriodicSite. Did you mean: 'species'?

## Checklist

Before a pull request can be merged, the following items must be checked:

* [x] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [X] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [x] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
