### PR TITLE
Update ASE wiki URL to fix link-check in CI

### DIFF
--- a/torch_sim/units.py
+++ b/torch_sim/units.py
@@ -15,7 +15,7 @@ class BaseConstant(float, Enum):
 
     References:
         http://arxiv.org/pdf/1507.07956.pdf
-        https://wiki.fysik.dtu.dk/ase/_modules/ase/units.html#create_units
+        https://docs.ase-lib.org/_modules/ase/units.html#create_units
     """
 
     def __new__(cls, value: float) -> Self:


### PR DESCRIPTION
## Summary

ase changed their doc URL which caused the link-check step to fail


## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
