### PR TITLE
fix(autobatching): detach states to stop UMA autograd-graph leak (swap loop + chunked init)

### DIFF
--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -491,14 +491,14 @@ def test_determine_max_batch_size_fibonacci(
 def test_detach_state_graph_drops_grad_but_keeps_values(
     si_sim_state: ts.SimState,
 ) -> None:
-    """`_detach_state_graph` strips grad graphs (the UMA leak) but preserves data.
+    """`detach_state_graph` strips grad graphs (the UMA leak) but preserves data.
 
     Models such as UMA return a graph-carrying ``energy`` (``requires_grad=True``)
     while their forces are detached; accumulating those graph-carrying states for
     the whole run is the memory leak. The helper must detach grad-carrying tensors
     in place, leave non-grad tensors untouched, and not change any values.
     """
-    from torch_sim.autobatching import _detach_state_graph
+    from torch_sim.autobatching import detach_state_graph
 
     # Give one tensor attribute an autograd graph, as UMA's energy would carry.
     grad_positions = (si_sim_state.positions.detach().clone().requires_grad_()) * 2
@@ -507,7 +507,7 @@ def test_detach_state_graph_drops_grad_but_keeps_values(
     masses_before = si_sim_state.masses  # a plain, non-grad tensor
     assert si_sim_state.positions.requires_grad
 
-    returned = _detach_state_graph(si_sim_state)
+    returned = detach_state_graph(si_sim_state)
 
     assert returned is si_sim_state  # detaches in place
     assert not si_sim_state.positions.requires_grad

--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -12,6 +12,7 @@ from torch_sim.autobatching import (
     determine_max_batch_size,
     to_constant_volume_bins,
 )
+from torch_sim.state import detach_state_graph
 from torch_sim.models.lennard_jones import LennardJonesModel
 
 
@@ -498,8 +499,6 @@ def test_detach_state_graph_drops_grad_but_keeps_values(
     the whole run is the memory leak. The helper must detach grad-carrying tensors
     in place, leave non-grad tensors untouched, and not change any values.
     """
-    from torch_sim.autobatching import detach_state_graph
-
     # Give one tensor attribute an autograd graph, as UMA's energy would carry.
     grad_positions = (si_sim_state.positions.detach().clone().requires_grad_()) * 2
     values_before = grad_positions.detach().clone()

--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -488,6 +488,34 @@ def test_determine_max_batch_size_fibonacci(
     assert max_size == 2
 
 
+def test_detach_state_graph_drops_grad_but_keeps_values(
+    si_sim_state: ts.SimState,
+) -> None:
+    """`_detach_state_graph` strips grad graphs (the UMA leak) but preserves data.
+
+    Models such as UMA return a graph-carrying ``energy`` (``requires_grad=True``)
+    while their forces are detached; accumulating those graph-carrying states for
+    the whole run is the memory leak. The helper must detach grad-carrying tensors
+    in place, leave non-grad tensors untouched, and not change any values.
+    """
+    from torch_sim.autobatching import _detach_state_graph
+
+    # Give one tensor attribute an autograd graph, as UMA's energy would carry.
+    grad_positions = (si_sim_state.positions.detach().clone().requires_grad_()) * 2
+    values_before = grad_positions.detach().clone()
+    si_sim_state.positions = grad_positions
+    masses_before = si_sim_state.masses  # a plain, non-grad tensor
+    assert si_sim_state.positions.requires_grad
+
+    returned = _detach_state_graph(si_sim_state)
+
+    assert returned is si_sim_state  # detaches in place
+    assert not si_sim_state.positions.requires_grad
+    assert si_sim_state.positions.grad_fn is None
+    assert torch.allclose(si_sim_state.positions, values_before)  # values unchanged
+    assert si_sim_state.masses is masses_before  # non-grad tensors left as-is
+
+
 @pytest.mark.parametrize("scale_factor", [1.1, 1.4])
 def test_determine_max_batch_size_small_scale_factor_no_infinite_loop(
     si_sim_state: ts.SimState,

--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -12,8 +12,8 @@ from torch_sim.autobatching import (
     determine_max_batch_size,
     to_constant_volume_bins,
 )
-from torch_sim.state import detach_state_graph
 from torch_sim.models.lennard_jones import LennardJonesModel
+from torch_sim.state import detach_state_graph
 
 
 def test_exact_fit():
@@ -513,6 +513,7 @@ def test_detach_state_graph_drops_grad_but_keeps_values(
     assert si_sim_state.positions.grad_fn is None
     assert torch.allclose(si_sim_state.positions, values_before)  # values unchanged
     assert si_sim_state.masses is masses_before  # non-grad tensors left as-is
+
 
 @pytest.mark.parametrize(
     "oom_message",

--- a/torch_sim/__init__.py
+++ b/torch_sim/__init__.py
@@ -25,7 +25,6 @@ from torch_sim import (
 from torch_sim.autobatching import (
     BinningAutoBatcher,
     InFlightAutoBatcher,
-    detach_state_graph,
 )
 from torch_sim.integrators import (
     INTEGRATOR_REGISTRY,
@@ -97,7 +96,7 @@ from torch_sim.runners import (
     optimize,
     static,
 )
-from torch_sim.state import SimState, concatenate_states, initialize_state
+from torch_sim.state import SimState, concatenate_states, initialize_state, detach_state_graph
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
 
 

--- a/torch_sim/__init__.py
+++ b/torch_sim/__init__.py
@@ -22,7 +22,11 @@ from torch_sim import (
     transforms,
     units,
 )
-from torch_sim.autobatching import BinningAutoBatcher, InFlightAutoBatcher
+from torch_sim.autobatching import (
+    BinningAutoBatcher,
+    InFlightAutoBatcher,
+    detach_state_graph,
+)
 from torch_sim.integrators import (
     INTEGRATOR_REGISTRY,
     Integrator,
@@ -145,6 +149,7 @@ __all__ = [
     "calc_temperature",
     "concatenate_states",
     "constraints",
+    "detach_state_graph",
     "elastic",
     "fire_init",
     "fire_step",

--- a/torch_sim/__init__.py
+++ b/torch_sim/__init__.py
@@ -22,10 +22,7 @@ from torch_sim import (
     transforms,
     units,
 )
-from torch_sim.autobatching import (
-    BinningAutoBatcher,
-    InFlightAutoBatcher,
-)
+from torch_sim.autobatching import BinningAutoBatcher, InFlightAutoBatcher
 from torch_sim.integrators import (
     INTEGRATOR_REGISTRY,
     Integrator,
@@ -96,7 +93,12 @@ from torch_sim.runners import (
     optimize,
     static,
 )
-from torch_sim.state import SimState, concatenate_states, initialize_state, detach_state_graph
+from torch_sim.state import (
+    SimState,
+    concatenate_states,
+    detach_state_graph,
+    initialize_state,
+)
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
 
 

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -186,7 +186,7 @@ def measure_model_memory_forward(state: SimState, model: ModelInterface) -> floa
     return torch.cuda.max_memory_allocated() / 1024**3  # Convert to GB
 
 
-def _detach_state_graph[T: SimState](state: T) -> T:
+def detach_state_graph[T: SimState](state: T) -> T:
     """Detach any autograd-graph-carrying tensors on a state, in place.
 
     Some models return graph-carrying outputs - notably UMA, whose ``energy``
@@ -1125,7 +1125,7 @@ class InFlightAutoBatcher[T: SimState]:
         # completed state would pin its swap's full forward graph - leaking GPU
         # memory (one graph per finished system) until the device fills.
         for completed_state in completed_states:
-            _detach_state_graph(completed_state)
+            detach_state_graph(completed_state)
 
         # necessary to ensure states that finish at the same time are ordered properly
         completed_states.reverse()

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -30,7 +30,7 @@ import torch
 import torch_sim as ts
 from torch_sim.models.interface import ModelInterface
 from torch_sim.neighbors import torchsim_nl
-from torch_sim.state import SimState
+from torch_sim.state import SimState, detach_state_graph
 from torch_sim.typing import MemoryScaling
 
 
@@ -190,32 +190,6 @@ def measure_model_memory_forward(state: SimState, model: ModelInterface) -> floa
     model(state)
 
     return torch.cuda.max_memory_allocated() / 1024**3  # Convert to GB
-
-
-def detach_state_graph[T: SimState](state: T) -> T:
-    """Detach any autograd-graph-carrying tensors on a state, in place.
-
-    Some models return graph-carrying outputs - notably UMA, whose ``energy``
-    keeps ``requires_grad=True`` even though its forces are already detached.
-    When a converged system is popped out of the running batch and accumulated
-    for the remainder of the run, such a tensor pins that swap's *entire*
-    forward autograd graph, so live GPU memory grows by roughly one graph per
-    finished system until the device fills - independent of the batch size and
-    unreclaimable by ``empty_cache`` (it is allocated, not cached). Completed
-    states are only ever read for their values, never differentiated, so
-    dropping the graph is safe.
-
-    Args:
-        state (SimState): State whose grad-carrying tensor attributes are
-            detached in place.
-
-    Returns:
-        SimState: The same state instance, with grad-carrying tensors detached.
-    """
-    for attr_name, attr_value in state.attributes.items():
-        if torch.is_tensor(attr_value) and attr_value.requires_grad:
-            setattr(state, attr_name, attr_value.detach())
-    return state
 
 
 def determine_max_batch_size(

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -186,6 +186,32 @@ def measure_model_memory_forward(state: SimState, model: ModelInterface) -> floa
     return torch.cuda.max_memory_allocated() / 1024**3  # Convert to GB
 
 
+def _detach_state_graph[T: SimState](state: T) -> T:
+    """Detach any autograd-graph-carrying tensors on a state, in place.
+
+    Some models return graph-carrying outputs - notably UMA, whose ``energy``
+    keeps ``requires_grad=True`` even though its forces are already detached.
+    When a converged system is popped out of the running batch and accumulated
+    for the remainder of the run, such a tensor pins that swap's *entire*
+    forward autograd graph, so live GPU memory grows by roughly one graph per
+    finished system until the device fills - independent of the batch size and
+    unreclaimable by ``empty_cache`` (it is allocated, not cached). Completed
+    states are only ever read for their values, never differentiated, so
+    dropping the graph is safe.
+
+    Args:
+        state (SimState): State whose grad-carrying tensor attributes are
+            detached in place.
+
+    Returns:
+        SimState: The same state instance, with grad-carrying tensors detached.
+    """
+    for attr_name, attr_value in state.attributes.items():
+        if torch.is_tensor(attr_value) and attr_value.requires_grad:
+            setattr(state, attr_name, attr_value.detach())
+    return state
+
+
 def determine_max_batch_size(
     state: SimState,
     model: ModelInterface,
@@ -1092,6 +1118,14 @@ class InFlightAutoBatcher[T: SimState]:
         completed_idx = torch.where(convergence_tensor)[0].tolist()
 
         completed_states = updated_state.pop(completed_idx)
+
+        # Drop any retained autograd graph before these states are accumulated
+        # for the rest of the run. A popped state preserves grad_fn, and models
+        # such as UMA return a graph-carrying energy, so without this each
+        # completed state would pin its swap's full forward graph - leaking GPU
+        # memory (one graph per finished system) until the device fills.
+        for completed_state in completed_states:
+            _detach_state_graph(completed_state)
 
         # necessary to ensure states that finish at the same time are ordered properly
         completed_states.reverse()

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -20,7 +20,7 @@ import torch_sim as ts
 from torch_sim.autobatching import (
     BinningAutoBatcher,
     InFlightAutoBatcher,
-    _detach_state_graph,
+    detach_state_graph,
 )
 from torch_sim.integrators import INTEGRATOR_REGISTRY, Integrator
 from torch_sim.integrators.md import MDState
@@ -485,7 +485,7 @@ def _chunked_apply[T: SimState](
     # The initialized states are only read for their values downstream, so
     # dropping the graph is safe. Mirrors the InFlightAutoBatcher fix.
     initialized_states = [
-        _detach_state_graph(fn(model=model, state=system, **init_kwargs))
+        detach_state_graph(fn(model=model, state=system, **init_kwargs))
         for system, _indices in autobatcher
     ]
 

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -17,10 +17,7 @@ import torch
 from tqdm import tqdm
 
 import torch_sim as ts
-from torch_sim.autobatching import (
-    BinningAutoBatcher,
-    InFlightAutoBatcher,
-)
+from torch_sim.autobatching import BinningAutoBatcher, InFlightAutoBatcher
 from torch_sim.integrators import INTEGRATOR_REGISTRY, Integrator
 from torch_sim.integrators.md import MDState
 from torch_sim.models.interface import ModelInterface

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -17,7 +17,11 @@ import torch
 from tqdm import tqdm
 
 import torch_sim as ts
-from torch_sim.autobatching import BinningAutoBatcher, InFlightAutoBatcher
+from torch_sim.autobatching import (
+    BinningAutoBatcher,
+    InFlightAutoBatcher,
+    _detach_state_graph,
+)
 from torch_sim.integrators import INTEGRATOR_REGISTRY, Integrator
 from torch_sim.integrators.md import MDState
 from torch_sim.models.interface import ModelInterface
@@ -472,10 +476,17 @@ def _chunked_apply[T: SimState](
     """
     autobatcher = BinningAutoBatcher(model=model, **batcher_kwargs)
     autobatcher.load_states(states)
-    initialized_states = []
 
+    # Each initialized bin is accumulated and held until every bin is done, then
+    # concatenated. Models such as UMA return a graph-carrying energy, so without
+    # detaching, every accumulated state would pin its bin's full forward autograd
+    # graph - live GPU memory then grows by roughly one graph per bin until the
+    # device fills mid-pass (fatal here: BinningAutoBatcher has no OOM recovery).
+    # The initialized states are only read for their values downstream, so
+    # dropping the graph is safe. Mirrors the InFlightAutoBatcher fix.
     initialized_states = [
-        fn(model=model, state=system, **init_kwargs) for system, _indices in autobatcher
+        _detach_state_graph(fn(model=model, state=system, **init_kwargs))
+        for system, _indices in autobatcher
     ]
 
     ordered_states = autobatcher.restore_original_order(initialized_states)

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -20,13 +20,12 @@ import torch_sim as ts
 from torch_sim.autobatching import (
     BinningAutoBatcher,
     InFlightAutoBatcher,
-    detach_state_graph,
 )
 from torch_sim.integrators import INTEGRATOR_REGISTRY, Integrator
 from torch_sim.integrators.md import MDState
 from torch_sim.models.interface import ModelInterface
 from torch_sim.optimizers import OPTIM_REGISTRY, FireState, Optimizer, OptimState
-from torch_sim.state import _CANONICAL_MODEL_KEYS, SimState
+from torch_sim.state import _CANONICAL_MODEL_KEYS, SimState, detach_state_graph
 from torch_sim.trajectory import TrajectoryReporter
 from torch_sim.typing import StateLike
 from torch_sim.units import UnitSystem

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -1003,6 +1003,33 @@ def _state_to_device[T: SimState](  # noqa: C901
     return type(state)(**attrs)
 
 
+def detach_state_graph[T: SimState](state: T) -> T:
+    """Detach any autograd-graph-carrying tensors on a state, in place.
+
+    Some models return graph-carrying outputs - notably UMA, whose ``energy``
+    keeps ``requires_grad=True`` even though its forces are already detached.
+    When a converged system is popped out of the running batch and accumulated
+    for the remainder of the run, such a tensor pins that swap's *entire*
+    forward autograd graph, so live GPU memory grows by roughly one graph per
+    finished system until the device fills - independent of the batch size and
+    unreclaimable by ``empty_cache`` (it is allocated, not cached). Completed
+    states are only ever read for their values, never differentiated, so
+    dropping the graph is safe.
+
+    Args:
+        state (SimState): State whose grad-carrying tensor attributes are
+            detached in place.
+
+    Returns:
+        SimState: The same state instance, with grad-carrying tensors detached.
+    """
+    for attr_name, attr_value in state.attributes.items():
+        if torch.is_tensor(attr_value) and attr_value.requires_grad:
+            setattr(state, attr_name, attr_value.detach())
+    return state
+
+
+
 def get_attrs_for_scope(
     state: SimState, scope: Literal["per-atom", "per-system", "global"]
 ) -> Generator[tuple[str, Any], None, None]:

--- a/torch_sim/state.py
+++ b/torch_sim/state.py
@@ -1029,7 +1029,6 @@ def detach_state_graph[T: SimState](state: T) -> T:
     return state
 
 
-
 def get_attrs_for_scope(
     state: SimState, scope: Literal["per-atom", "per-system", "global"]
 ) -> Generator[tuple[str, Any], None, None]:


### PR DESCRIPTION
## Problem

Some models return graph-carrying outputs — notably UMA, whose `energy` keeps
`requires_grad=True` even though its forces are already detached. Any state that is
retained after a forward pass therefore pins that pass's **entire forward autograd graph**.
`torch_sim.optimize` retains such states in two places, and both leak GPU memory until the
device fills. Because the leak is *allocated* memory (not cached), `torch.cuda.empty_cache()`
cannot reclaim it, and cache-clearing / allocator-config workarounds don't help.

### 1. `InFlightAutoBatcher` swap loop

`optimize` accumulates every converged system (via `InFlightAutoBatcher.next_batch` → the
caller's completed-states list) for the entire run so it can restore the original order at
the end. A state popped out of the running batch **preserves `grad_fn`**, so each retained
completed state pins the full forward graph of the swap it finished in — one live graph per
finished system. `torch.cuda.memory_allocated` climbs monotonically (tens of MB per
structure) until OOM.

Reproduced with `uma-s-1p1` over a ~4300-structure molecular library (FIRE, D3 on): live
memory climbs from ~13 GB to 24 GB over ~356 swaps and OOMs; with this fix it stays **flat
at ~13 GB across the entire run** (validated to full completion, twice).

### 2. `_chunked_apply` optimizer-state init pass

Before the swap loop, `optimize` initializes the optimizer state over **all** systems via
`_chunked_apply`, which runs the init fn per bin through a `BinningAutoBatcher` and
accumulates every result in a GPU-resident list. The same grad-carrying-energy states are
held here too, so live memory grows by ~one graph per bin. Unlike the swap loop,
`BinningAutoBatcher` has **no runtime OOM recovery**, so a bin that tips over the device is
**fatal** — and this bites larger models before the swap loop is ever reached.

Reproduced with `uma-m-1p1` over the same ~4300-structure library (FIRE, D3 on): OOMs
~halfway through the init pass (bin 73/154), completely unaffected by `max_memory_padding`
(0.95 → bin 73, 0.90 → bin 78 — padding only shifts the crash a few bins, as expected for
an accumulation leak). With this fix the init pass turns from a monotonic climb into a
bounded sawtooth and the full run completes.

This is distinct from the LBFGS/BFGS history-buffer accumulation fixed in #559/#568 — it
affects the plain optimization loop (e.g. FIRE) via the model's own energy tensor.

## Fix

Add a small `detach_state_graph()` helper in `torch_sim/autobatching.py` and call it on
states as they are retained, at **both** sites:

- `InFlightAutoBatcher.next_batch`, on completed states before they are accumulated;
- `_chunked_apply` (in `torch_sim/runners.py`), on each initialized state before it is
  accumulated.

Retained states are only ever read for their values (never differentiated), so dropping the
graph is safe and changes no numerical results. Because the helper is now used across
modules, it is promoted from a private `_detach_state_graph` to a public
`torch_sim.detach_state_graph` (exported in `__all__`).

## Tests / validation

`tests/test_autobatching.py`: `test_detach_state_graph_drops_grad_but_keeps_values` —
asserts grad-carrying tensors are detached in place, non-grad tensors are left untouched,
and values are unchanged. Full autobatching suite green; ruff + ty clean.

Full 4272-structure benchmark now completes for **all fire configs** with the default
`max_memory_padding=0.95`: `uma-s-1p1`, `uma-s-1p2`, `uma-m-1p1`, `orb-v3-direct`,
`orb-v3-conservative` — all 4272/4272, no regression. `uma-m-1p1` was fatal at every padding
without the `_chunked_apply` fix.
