### PR TITLE
Remove metal units

### DIFF
--- a/docs/user/overview.md
+++ b/docs/user/overview.md
@@ -3,7 +3,8 @@
 ## Runners
 
 TorchSim makes atomistic simulation easy with a fully featured high-level API. It introduces three "runner" functions: `integrate` for molecular dynamics, `optimize` for relaxation, and `static` for static evaluation. All functions share a similar signature and support auto batching, trajectory reporting, diverse models, and IO with popular libraries. Further, they support all of this across various simulation types, such as integration with NVT or NPT and optimization with gradient descent or FIRE.
-All runners use the [metal unit system](https://docs.lammps.org/units.html).
+The high-level MD runner accepts temperature in kelvin and timestep in picoseconds.
+States and model outputs use angstrom, electronvolt, and atomic mass units.
 
 Learn more in [Introduction to TorchSim](../tutorials/high_level_tutorial.ipynb)
 

--- a/examples/scripts/3_dynamics.py
+++ b/examples/scripts/3_dynamics.py
@@ -16,6 +16,7 @@ This script demonstrates molecular dynamics simulations with:
 import itertools
 import os
 import time
+from math import sqrt
 
 import torch
 from ase.build import bulk
@@ -25,11 +26,7 @@ import torch_sim as ts
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.models.mace import MaceModel
 from torch_sim.telemetry import configure_logging, get_logger
-from torch_sim.units import (
-    BAR_TO_EV_PER_ANGSTROM3,
-    BOLTZMANN_CONSTANT_EV_PER_K,
-    PS_TO_INTERNAL_TIME,
-)
+from torch_sim.units import bc, uc
 
 
 configure_logging(log_file="3_dynamics.log")
@@ -117,8 +114,12 @@ lj_model = LennardJonesModel(
 results = lj_model(state)
 
 # Set up NVE simulation
-kT = torch.tensor(80 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype)
-dt = torch.tensor(0.001 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)
+kT = torch.tensor(80 * (bc.k_B / bc.e), device=device, dtype=dtype)
+dt = torch.tensor(
+    0.001 * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+    device=device,
+    dtype=dtype,
+)
 
 # Initialize NVE integrator
 state.rng = 1
@@ -184,10 +185,12 @@ state = ts.SimState(
 results = mace_model(state)
 
 # Setup NVE MD simulation parameters
-kT = torch.tensor(
-    1000 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype
-)  # 1000 K
-dt = torch.tensor(0.002 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # 2 fs
+kT = torch.tensor(1000 * (bc.k_B / bc.e), device=device, dtype=dtype)  # 1000 K
+dt = torch.tensor(
+    0.002 * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+    device=device,
+    dtype=dtype,
+)  # 2 fs
 
 # Initialize NVE integrator
 state.rng = 1
@@ -230,11 +233,17 @@ state = ts.SimState(
     positions=positions, masses=masses, cell=cell, atomic_numbers=atomic_numbers, pbc=True
 )
 
-dt = torch.tensor(0.002 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # 2 fs
-kT = torch.tensor(
-    1000 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype
-)  # 1000 K
-gamma = torch.tensor(10 / PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # ps^-1
+dt = torch.tensor(
+    0.002 * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+    device=device,
+    dtype=dtype,
+)  # 2 fs
+kT = torch.tensor(1000 * (bc.k_B / bc.e), device=device, dtype=dtype)  # 1000 K
+gamma = torch.tensor(
+    10 / (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+    device=device,
+    dtype=dtype,
+)  # ps^-1
 
 # Initialize NVT Langevin integrator
 state.rng = 1
@@ -243,19 +252,15 @@ state = ts.nvt_langevin_init(model=mace_model, state=state, kT=kT)
 log.info("Starting NVT Langevin simulation...")
 for step in range(N_steps):
     if step % 100 == 0:
-        temp = (
-            ts.calc_kT(
-                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
-            )
-            / BOLTZMANN_CONSTANT_EV_PER_K
-        )
+        temp = ts.calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        ) / (bc.k_B / bc.e)
         log.info(f"Step {step}: Temperature: {temp.item():.4f} K")
     state = ts.nvt_langevin_step(state=state, model=mace_model, dt=dt, kT=kT, gamma=gamma)
 
-final_temp = (
-    ts.calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
-    / BOLTZMANN_CONSTANT_EV_PER_K
-)
+final_temp = ts.calc_kT(
+    masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+) / (bc.k_B / bc.e)
 log.info(f"Final temperature: {final_temp.item():.4f} K")
 
 
@@ -274,32 +279,30 @@ state = ts.io.atoms_to_state(si_dc, device=device, dtype=dtype)
 # Run initial inference
 results = mace_model(state)
 
-dt = torch.tensor(0.002 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # 2 fs
-kT = torch.tensor(
-    1000 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype
-)  # 1000 K
+dt = torch.tensor(
+    0.002 * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+    device=device,
+    dtype=dtype,
+)  # 2 fs
+kT = torch.tensor(1000 * (bc.k_B / bc.e), device=device, dtype=dtype)  # 1000 K
 
 state = ts.nvt_nose_hoover_init(state=state, model=mace_model, kT=kT, dt=dt)
 
 log.info("Starting NVT Nose-Hoover simulation...")
 for step in range(N_steps):
     if step % 100 == 0:
-        temp = (
-            ts.calc_kT(
-                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
-            )
-            / BOLTZMANN_CONSTANT_EV_PER_K
-        )
+        temp = ts.calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        ) / (bc.k_B / bc.e)
         invariant = float(ts.nvt_nose_hoover_invariant(state, kT=kT))
         log.info(
             f"Step {step}: Temperature: {temp.item():.4f} K, Invariant: {invariant:.4f}"
         )
     state = ts.nvt_nose_hoover_step(state=state, model=mace_model, dt=dt, kT=kT)
 
-final_temp = (
-    ts.calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
-    / BOLTZMANN_CONSTANT_EV_PER_K
-)
+final_temp = ts.calc_kT(
+    masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+) / (bc.k_B / bc.e)
 log.info(f"Final temperature: {final_temp.item():.4f} K")
 
 
@@ -330,10 +333,10 @@ results = mace_model_stress(state)
 
 N_steps_nvt = 100 if SMOKE_TEST else 1_000
 N_steps_npt = 100 if SMOKE_TEST else 1_000
-dt = 0.001 * PS_TO_INTERNAL_TIME  # 1 fs
-kT = torch.tensor(300 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype)  # 300 K
+dt = 0.001 * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s)  # 1 fs
+kT = torch.tensor(300 * (bc.k_B / bc.e), device=device, dtype=dtype)  # 300 K
 target_pressure = torch.tensor(
-    0.0 * BAR_TO_EV_PER_ANGSTROM3, device=device, dtype=dtype
+    0.0 * (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e), device=device, dtype=dtype
 )  # 0 bar
 
 # Initialize NPT with NVT equilibration
@@ -344,12 +347,9 @@ state = ts.npt_nose_hoover_isotropic_init(
 log.info("Running NVT equilibration phase...")
 for step in range(N_steps_nvt):
     if step % 100 == 0:
-        temp = (
-            ts.calc_kT(
-                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
-            )
-            / BOLTZMANN_CONSTANT_EV_PER_K
-        )
+        temp = ts.calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        ) / (bc.k_B / bc.e)
         invariant = float(
             ts.npt_nose_hoover_isotropic_invariant(
                 state, kT=kT, external_pressure=target_pressure
@@ -374,12 +374,9 @@ state = ts.npt_nose_hoover_isotropic_init(
 log.info("Running NPT simulation...")
 for step in range(N_steps_npt):
     if step % 100 == 0:
-        temp = (
-            ts.calc_kT(
-                masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
-            )
-            / BOLTZMANN_CONSTANT_EV_PER_K
-        )
+        temp = ts.calc_kT(
+            masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+        ) / (bc.k_B / bc.e)
         invariant = float(
             ts.npt_nose_hoover_isotropic_invariant(
                 state, kT=kT, external_pressure=target_pressure
@@ -405,10 +402,9 @@ for step in range(N_steps_npt):
         external_pressure=target_pressure,
     )
 
-final_temp = (
-    ts.calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
-    / BOLTZMANN_CONSTANT_EV_PER_K
-)
+final_temp = ts.calc_kT(
+    masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
+) / (bc.k_B / bc.e)
 log.info(f"Final temperature: {final_temp.item():.4f} K")
 
 final_stress = mace_model_stress(state)["stress"]

--- a/examples/scripts/3_dynamics.py
+++ b/examples/scripts/3_dynamics.py
@@ -25,7 +25,11 @@ import torch_sim as ts
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.models.mace import MaceModel
 from torch_sim.telemetry import configure_logging, get_logger
-from torch_sim.units import MetalUnits as Units
+from torch_sim.units import (
+    BAR_TO_EV_PER_ANGSTROM3,
+    BOLTZMANN_CONSTANT_EV_PER_K,
+    PS_TO_INTERNAL_TIME,
+)
 
 
 configure_logging(log_file="3_dynamics.log")
@@ -113,8 +117,8 @@ lj_model = LennardJonesModel(
 results = lj_model(state)
 
 # Set up NVE simulation
-kT = torch.tensor(80 * Units.temperature, device=device, dtype=dtype)
-dt = torch.tensor(0.001 * Units.time, device=device, dtype=dtype)
+kT = torch.tensor(80 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype)
+dt = torch.tensor(0.001 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)
 
 # Initialize NVE integrator
 state.rng = 1
@@ -180,8 +184,10 @@ state = ts.SimState(
 results = mace_model(state)
 
 # Setup NVE MD simulation parameters
-kT = torch.tensor(1000 * Units.temperature, device=device, dtype=dtype)  # 1000 K
-dt = torch.tensor(0.002 * Units.time, device=device, dtype=dtype)  # 2 fs
+kT = torch.tensor(
+    1000 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype
+)  # 1000 K
+dt = torch.tensor(0.002 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # 2 fs
 
 # Initialize NVE integrator
 state.rng = 1
@@ -224,9 +230,11 @@ state = ts.SimState(
     positions=positions, masses=masses, cell=cell, atomic_numbers=atomic_numbers, pbc=True
 )
 
-dt = torch.tensor(0.002 * Units.time, device=device, dtype=dtype)  # 2 fs
-kT = torch.tensor(1000 * Units.temperature, device=device, dtype=dtype)  # 1000 K
-gamma = torch.tensor(10 / Units.time, device=device, dtype=dtype)  # ps^-1
+dt = torch.tensor(0.002 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # 2 fs
+kT = torch.tensor(
+    1000 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype
+)  # 1000 K
+gamma = torch.tensor(10 / PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # ps^-1
 
 # Initialize NVT Langevin integrator
 state.rng = 1
@@ -239,14 +247,14 @@ for step in range(N_steps):
             ts.calc_kT(
                 masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
             )
-            / Units.temperature
+            / BOLTZMANN_CONSTANT_EV_PER_K
         )
         log.info(f"Step {step}: Temperature: {temp.item():.4f} K")
     state = ts.nvt_langevin_step(state=state, model=mace_model, dt=dt, kT=kT, gamma=gamma)
 
 final_temp = (
     ts.calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
-    / Units.temperature
+    / BOLTZMANN_CONSTANT_EV_PER_K
 )
 log.info(f"Final temperature: {final_temp.item():.4f} K")
 
@@ -266,8 +274,10 @@ state = ts.io.atoms_to_state(si_dc, device=device, dtype=dtype)
 # Run initial inference
 results = mace_model(state)
 
-dt = torch.tensor(0.002 * Units.time, device=device, dtype=dtype)  # 2 fs
-kT = torch.tensor(1000 * Units.temperature, device=device, dtype=dtype)  # 1000 K
+dt = torch.tensor(0.002 * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)  # 2 fs
+kT = torch.tensor(
+    1000 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype
+)  # 1000 K
 
 state = ts.nvt_nose_hoover_init(state=state, model=mace_model, kT=kT, dt=dt)
 
@@ -278,7 +288,7 @@ for step in range(N_steps):
             ts.calc_kT(
                 masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
             )
-            / Units.temperature
+            / BOLTZMANN_CONSTANT_EV_PER_K
         )
         invariant = float(ts.nvt_nose_hoover_invariant(state, kT=kT))
         log.info(
@@ -288,7 +298,7 @@ for step in range(N_steps):
 
 final_temp = (
     ts.calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
-    / Units.temperature
+    / BOLTZMANN_CONSTANT_EV_PER_K
 )
 log.info(f"Final temperature: {final_temp.item():.4f} K")
 
@@ -320,9 +330,11 @@ results = mace_model_stress(state)
 
 N_steps_nvt = 100 if SMOKE_TEST else 1_000
 N_steps_npt = 100 if SMOKE_TEST else 1_000
-dt = 0.001 * Units.time  # 1 fs
-kT = torch.tensor(300 * Units.temperature, device=device, dtype=dtype)  # 300 K
-target_pressure = torch.tensor(0.0 * Units.pressure, device=device, dtype=dtype)  # 0 bar
+dt = 0.001 * PS_TO_INTERNAL_TIME  # 1 fs
+kT = torch.tensor(300 * BOLTZMANN_CONSTANT_EV_PER_K, device=device, dtype=dtype)  # 300 K
+target_pressure = torch.tensor(
+    0.0 * BAR_TO_EV_PER_ANGSTROM3, device=device, dtype=dtype
+)  # 0 bar
 
 # Initialize NPT with NVT equilibration
 state = ts.npt_nose_hoover_isotropic_init(
@@ -336,7 +348,7 @@ for step in range(N_steps_nvt):
             ts.calc_kT(
                 masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
             )
-            / Units.temperature
+            / BOLTZMANN_CONSTANT_EV_PER_K
         )
         invariant = float(
             ts.npt_nose_hoover_isotropic_invariant(
@@ -366,7 +378,7 @@ for step in range(N_steps_npt):
             ts.calc_kT(
                 masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
             )
-            / Units.temperature
+            / BOLTZMANN_CONSTANT_EV_PER_K
         )
         invariant = float(
             ts.npt_nose_hoover_isotropic_invariant(
@@ -395,7 +407,7 @@ for step in range(N_steps_npt):
 
 final_temp = (
     ts.calc_kT(masses=state.masses, momenta=state.momenta, system_idx=state.system_idx)
-    / Units.temperature
+    / BOLTZMANN_CONSTANT_EV_PER_K
 )
 log.info(f"Final temperature: {final_temp.item():.4f} K")
 

--- a/examples/scripts/4_high_level_api.py
+++ b/examples/scripts/4_high_level_api.py
@@ -27,7 +27,6 @@ from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.models.mace import MaceModel
 from torch_sim.telemetry import configure_logging, get_logger
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
-from torch_sim.units import MetalUnits
 
 
 configure_logging(log_file="4_high_level_api.log")
@@ -250,9 +249,7 @@ final_state = ts.optimize(
     system=systems,
     model=mace_model,
     optimizer=ts.Optimizer.fire,
-    convergence_fn=lambda state, last_energy: (
-        last_energy - state.energy < 1e-6 * MetalUnits.energy
-    ),
+    convergence_fn=lambda state, last_energy: last_energy - state.energy < 1e-6,
     max_steps=10 if SMOKE_TEST else 1000,
     init_kwargs=dict(cell_filter=ts.CellFilter.unit),
 )

--- a/examples/scripts/7_others.py
+++ b/examples/scripts/7_others.py
@@ -14,6 +14,7 @@ This script demonstrates:
 # ///
 
 import os
+from math import sqrt
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -27,7 +28,7 @@ from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.neighbors import torch_nl_linked_cell, torch_nl_n2
 from torch_sim.properties.correlations import VelocityAutoCorrelation
 from torch_sim.telemetry import configure_logging, get_logger
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
+from torch_sim.units import bc, uc
 
 
 configure_logging(log_file="7_others.log")
@@ -146,8 +147,12 @@ log.info(f"  Cutoff: {cutoff:.2f} Å")
 
 # Simulation parameters
 timestep = 0.001  # ps (1 fs)
-dt = torch.tensor(timestep * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)
-temp_kT = temperature * BOLTZMANN_CONSTANT_EV_PER_K  # noqa: N816
+dt = torch.tensor(
+    timestep * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+    device=device,
+    dtype=dtype,
+)
+temp_kT = temperature * (bc.k_B / bc.e)  # noqa: N816
 kT = torch.tensor(temp_kT, device=device, dtype=dtype)
 
 # Initialize NVE integrator

--- a/examples/scripts/7_others.py
+++ b/examples/scripts/7_others.py
@@ -27,7 +27,7 @@ from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.neighbors import torch_nl_linked_cell, torch_nl_n2
 from torch_sim.properties.correlations import VelocityAutoCorrelation
 from torch_sim.telemetry import configure_logging, get_logger
-from torch_sim.units import MetalUnits as Units
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
 
 
 configure_logging(log_file="7_others.log")
@@ -146,8 +146,8 @@ log.info(f"  Cutoff: {cutoff:.2f} Å")
 
 # Simulation parameters
 timestep = 0.001  # ps (1 fs)
-dt = torch.tensor(timestep * Units.time, device=device, dtype=dtype)
-temp_kT = temperature * Units.temperature  # noqa: N816
+dt = torch.tensor(timestep * PS_TO_INTERNAL_TIME, device=device, dtype=dtype)
+temp_kT = temperature * BOLTZMANN_CONSTANT_EV_PER_K  # noqa: N816
 kT = torch.tensor(temp_kT, device=device, dtype=dtype)
 
 # Initialize NVE integrator

--- a/examples/tutorials/high_level_tutorial.py
+++ b/examples/tutorials/high_level_tutorial.py
@@ -400,7 +400,7 @@ print(f"Any converged? {torch.any(convergence_tensor).item()}")
 For convenience TorchSim provides constructors for common convergence functions.
 """
 
-# %% we use metal units for these functions
+# %% tolerances use the same eV and angstrom quantities as model outputs
 energy_convergence_fn = ts.generate_energy_convergence_fn(energy_tol=1e-6)
 force_convergence_fn = ts.generate_force_convergence_fn(force_tol=1e-3)
 

--- a/examples/tutorials/hybrid_swap_tutorial.py
+++ b/examples/tutorials/hybrid_swap_tutorial.py
@@ -125,9 +125,9 @@ Now we'll initialize both the MD and Monte Carlo components. We:
 """
 
 # %%
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
+from torch_sim.units import bc
 
-kT = 1000 * BOLTZMANN_CONSTANT_EV_PER_K
+kT = 1000 * (bc.k_B / bc.e)
 
 # Initialize NVT Langevin dynamics state
 state.rng = 42

--- a/examples/tutorials/hybrid_swap_tutorial.py
+++ b/examples/tutorials/hybrid_swap_tutorial.py
@@ -125,9 +125,9 @@ Now we'll initialize both the MD and Monte Carlo components. We:
 """
 
 # %%
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
 
-kT = 1000 * MetalUnits.temperature
+kT = 1000 * BOLTZMANN_CONSTANT_EV_PER_K
 
 # Initialize NVT Langevin dynamics state
 state.rng = 42

--- a/examples/tutorials/low_level_tutorial.py
+++ b/examples/tutorials/low_level_tutorial.py
@@ -175,16 +175,16 @@ for step in range(5):
 Similarly, we can do molecular dynamics of the systems. We need to make sure we are
 using correct units for the integrator. TorchSim provides a `units.py` module to
 help with the units system and conversions. All currently supported models implement
-[MetalUnits](https://docs.lammps.org/units.html), so we must convert our units into
+TorchSim internal units, so we must convert our units into
 that system.
 """
 
 # %%
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
 
-dt = 0.002 * MetalUnits.time  # Timestep (ps)
-kT = 300 * MetalUnits.temperature  # Initial temperature (K)
-gamma = 10 / MetalUnits.time  # Langevin friction coefficient (ps^-1)
+dt = 0.002 * PS_TO_INTERNAL_TIME  # Timestep (ps)
+kT = 300 * BOLTZMANN_CONSTANT_EV_PER_K  # Initial temperature (K)
+gamma = 10 / PS_TO_INTERNAL_TIME  # Langevin friction coefficient (ps^-1)
 
 
 # %% [markdown]
@@ -218,7 +218,7 @@ for step in range(30):
         temp_E_units = ts.calc_kT(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
-        temp = temp_E_units / MetalUnits.temperature
+        temp = temp_E_units / BOLTZMANN_CONSTANT_EV_PER_K
         print(f"{step=}: Temperature: {temp}")
 
 

--- a/examples/tutorials/low_level_tutorial.py
+++ b/examples/tutorials/low_level_tutorial.py
@@ -172,19 +172,21 @@ for step in range(5):
 """
 ## NVT Langevin Dynamics
 
-Similarly, we can do molecular dynamics of the systems. We need to make sure we are
-using correct units for the integrator. TorchSim provides a `units.py` module to
-help with the units system and conversions. All currently supported models implement
-TorchSim internal units, so we must convert our units into
-that system.
+Similarly, we can do molecular dynamics of the systems. Low-level integrators consume
+thermal energy and a timestep coherent with the state's eV, angstrom, and amu values.
+Here those values are derived directly from the physical constants.
 """
 
 # %%
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
+from math import sqrt
 
-dt = 0.002 * PS_TO_INTERNAL_TIME  # Timestep (ps)
-kT = 300 * BOLTZMANN_CONSTANT_EV_PER_K  # Initial temperature (K)
-gamma = 10 / PS_TO_INTERNAL_TIME  # Langevin friction coefficient (ps^-1)
+from torch_sim.units import bc, uc
+
+dt = 0.002 * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s)  # Timestep (ps)
+kT = 300 * (bc.k_B / bc.e)  # Initial temperature (K)
+gamma = 10 / (
+    sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s
+)  # Langevin friction coefficient (ps^-1)
 
 
 # %% [markdown]
@@ -218,7 +220,7 @@ for step in range(30):
         temp_E_units = ts.calc_kT(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
-        temp = temp_E_units / BOLTZMANN_CONSTANT_EV_PER_K
+        temp = temp_E_units / (bc.k_B / bc.e)
         print(f"{step=}: Temperature: {temp}")
 
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -18,7 +18,7 @@ from torch_sim.models.interface import ModelInterface
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.optimizers import FireFlavor
 from torch_sim.transforms import get_centers_of_mass
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
 
 
 def _run_quasi_newton(
@@ -100,7 +100,7 @@ def test_fix_com_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJonesM
     """Test FixCom constraint in NVT Langevin dynamics."""
     n_steps = 1000
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     dofs_before = cu_sim_state.get_number_of_degrees_of_freedom()
     cu_sim_state.constraints = [FixCom([0])]
@@ -125,7 +125,7 @@ def test_fix_com_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJonesM
             system_idx=state.system_idx,
             dof_per_system=state.get_number_of_degrees_of_freedom(),
         )
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
     temperatures = torch.stack(temperatures)
 
     traj_positions = torch.stack(positions)
@@ -147,7 +147,7 @@ def test_fix_atoms_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJone
     """Test FixAtoms constraint in NVT Langevin dynamics."""
     n_steps = 1000
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     dofs_before = cu_sim_state.get_number_of_degrees_of_freedom()
     cu_sim_state.constraints = [FixAtoms(atom_idx=torch.tensor([0, 1], dtype=torch.long))]
@@ -166,7 +166,7 @@ def test_fix_atoms_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJone
             system_idx=state.system_idx,
             dof_per_system=state.get_number_of_degrees_of_freedom(),
         )
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
     temperatures = torch.stack(temperatures)
     traj_positions = torch.stack(positions)
 
@@ -568,7 +568,7 @@ def test_integrators_with_constraints(
 ) -> None:
     """Test all integrators respect constraints."""
     cu_sim_state.constraints = [constraint]
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
     dt = torch.tensor(0.001, dtype=DTYPE)
 
     # Store initial state
@@ -645,14 +645,14 @@ def test_multiple_constraints_and_dof(
     state = ts.nvt_langevin_init(
         cu_sim_state,
         lj_model,
-        kT=torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature,
+        kT=torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
     )
     for _ in range(200):
         state = ts.nvt_langevin_step(
             state,
             lj_model,
             dt=torch.tensor(0.001, dtype=DTYPE),
-            kT=torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature,
+            kT=torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
         )
     assert torch.allclose(state.positions[0], initial_pos, atol=1e-6)
     final_com = get_centers_of_mass(
@@ -921,7 +921,7 @@ def test_temperature_with_constrained_dof(
     state = ts.nvt_langevin_init(
         cu_sim_state,
         lj_model,
-        kT=torch.tensor(target, dtype=DTYPE) * MetalUnits.temperature,
+        kT=torch.tensor(target, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
     )
     temps = []
     for _ in range(4000):
@@ -929,10 +929,10 @@ def test_temperature_with_constrained_dof(
             state,
             lj_model,
             dt=torch.tensor(0.001, dtype=DTYPE),
-            kT=torch.tensor(target, dtype=DTYPE) * MetalUnits.temperature,
+            kT=torch.tensor(target, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
         )
         temp = state.calc_kT()
-        temps.append(temp / MetalUnits.temperature)
+        temps.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
     avg = torch.mean(torch.stack(temps)[500:])
     assert abs(avg - target) / target < 0.30
 

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -18,7 +18,7 @@ from torch_sim.models.interface import ModelInterface
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.optimizers import FireFlavor
 from torch_sim.transforms import get_centers_of_mass
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
+from torch_sim.units import bc
 
 
 def _run_quasi_newton(
@@ -100,7 +100,7 @@ def test_fix_com_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJonesM
     """Test FixCom constraint in NVT Langevin dynamics."""
     n_steps = 1000
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=DTYPE) * (bc.k_B / bc.e)
 
     dofs_before = cu_sim_state.get_number_of_degrees_of_freedom()
     cu_sim_state.constraints = [FixCom([0])]
@@ -125,7 +125,7 @@ def test_fix_com_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJonesM
             system_idx=state.system_idx,
             dof_per_system=state.get_number_of_degrees_of_freedom(),
         )
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
     temperatures = torch.stack(temperatures)
 
     traj_positions = torch.stack(positions)
@@ -147,7 +147,7 @@ def test_fix_atoms_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJone
     """Test FixAtoms constraint in NVT Langevin dynamics."""
     n_steps = 1000
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=DTYPE) * (bc.k_B / bc.e)
 
     dofs_before = cu_sim_state.get_number_of_degrees_of_freedom()
     cu_sim_state.constraints = [FixAtoms(atom_idx=torch.tensor([0, 1], dtype=torch.long))]
@@ -166,7 +166,7 @@ def test_fix_atoms_nvt_langevin(cu_sim_state: ts.SimState, lj_model: LennardJone
             system_idx=state.system_idx,
             dof_per_system=state.get_number_of_degrees_of_freedom(),
         )
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
     temperatures = torch.stack(temperatures)
     traj_positions = torch.stack(positions)
 
@@ -568,7 +568,7 @@ def test_integrators_with_constraints(
 ) -> None:
     """Test all integrators respect constraints."""
     cu_sim_state.constraints = [constraint]
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
     dt = torch.tensor(0.001, dtype=DTYPE)
 
     # Store initial state
@@ -645,14 +645,14 @@ def test_multiple_constraints_and_dof(
     state = ts.nvt_langevin_init(
         cu_sim_state,
         lj_model,
-        kT=torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
+        kT=torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e),
     )
     for _ in range(200):
         state = ts.nvt_langevin_step(
             state,
             lj_model,
             dt=torch.tensor(0.001, dtype=DTYPE),
-            kT=torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
+            kT=torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e),
         )
     assert torch.allclose(state.positions[0], initial_pos, atol=1e-6)
     final_com = get_centers_of_mass(
@@ -921,7 +921,7 @@ def test_temperature_with_constrained_dof(
     state = ts.nvt_langevin_init(
         cu_sim_state,
         lj_model,
-        kT=torch.tensor(target, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
+        kT=torch.tensor(target, dtype=DTYPE) * (bc.k_B / bc.e),
     )
     temps = []
     for _ in range(4000):
@@ -929,10 +929,10 @@ def test_temperature_with_constrained_dof(
             state,
             lj_model,
             dt=torch.tensor(0.001, dtype=DTYPE),
-            kT=torch.tensor(target, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K,
+            kT=torch.tensor(target, dtype=DTYPE) * (bc.k_B / bc.e),
         )
         temp = state.calc_kT()
-        temps.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temps.append(temp / (bc.k_B / bc.e))
     avg = torch.mean(torch.stack(temps)[500:])
     assert abs(avg - target) / target < 0.30
 

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -3,13 +3,7 @@ import torch
 
 import torch_sim as ts
 from torch_sim.state import get_attrs_for_scope
-from torch_sim.units import (
-    BAR_TO_EV_PER_ANGSTROM3,
-    BOLTZMANN_CONSTANT_EV_PER_K,
-    PS_TO_INTERNAL_TIME,
-    BaseConstant,
-    UnitConversion,
-)
+from torch_sim.units import BaseConstant, UnitConversion
 
 
 def _make_state_with_extras(n_atoms: int = 4, n_systems: int = 2) -> ts.SimState:
@@ -376,8 +370,3 @@ class TestUnitsEnum:
         gpa = UnitConversion.eV_per_Ang3_to_GPa
         assert gpa > 100  # ~160.2
         assert isinstance(gpa + 0.0, float)
-
-    def test_internal_unit_conversion_constants(self):
-        assert pytest.approx(8.6173303e-5) == BOLTZMANN_CONSTANT_EV_PER_K
-        assert pytest.approx(98.22695) == PS_TO_INTERNAL_TIME
-        assert pytest.approx(6.2415091e-7) == BAR_TO_EV_PER_ANGSTROM3

--- a/tests/test_extras.py
+++ b/tests/test_extras.py
@@ -3,7 +3,13 @@ import torch
 
 import torch_sim as ts
 from torch_sim.state import get_attrs_for_scope
-from torch_sim.units import BaseConstant, UnitConversion
+from torch_sim.units import (
+    BAR_TO_EV_PER_ANGSTROM3,
+    BOLTZMANN_CONSTANT_EV_PER_K,
+    PS_TO_INTERNAL_TIME,
+    BaseConstant,
+    UnitConversion,
+)
 
 
 def _make_state_with_extras(n_atoms: int = 4, n_systems: int = 2) -> ts.SimState:
@@ -370,3 +376,8 @@ class TestUnitsEnum:
         gpa = UnitConversion.eV_per_Ang3_to_GPa
         assert gpa > 100  # ~160.2
         assert isinstance(gpa + 0.0, float)
+
+    def test_internal_unit_conversion_constants(self):
+        assert pytest.approx(8.6173303e-5) == BOLTZMANN_CONSTANT_EV_PER_K
+        assert pytest.approx(98.22695) == PS_TO_INTERNAL_TIME
+        assert pytest.approx(6.2415091e-7) == BAR_TO_EV_PER_ANGSTROM3

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -1,3 +1,5 @@
+from math import sqrt
+
 import pytest
 import torch
 
@@ -7,11 +9,7 @@ from torch_sim.integrators import initialize_momenta
 from torch_sim.integrators.npt import _npt_langevin_anisotropic_compute_cell_force
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.state import coerce_prng
-from torch_sim.units import (
-    BAR_TO_EV_PER_ANGSTROM3,
-    BOLTZMANN_CONSTANT_EV_PER_K,
-    PS_TO_INTERNAL_TIME,
-)
+from torch_sim.units import bc, uc
 
 
 def test_initialize_momenta_basic():
@@ -89,8 +87,10 @@ def test_npt_langevin(
 ) -> None:
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
     alpha = 40 * dt
     cell_alpha = alpha
     b_tau = 1 / (1000 * dt)
@@ -124,7 +124,7 @@ def test_npt_langevin(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -141,7 +141,7 @@ def test_npt_langevin(
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 150.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -163,9 +163,13 @@ def test_npt_langevin_isotropic(
     ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel
 ) -> None:
     n_steps = 200
-    dt = torch.tensor(0.001, dtype=DTYPE) * PS_TO_INTERNAL_TIME
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
+    dt = torch.tensor(0.001, dtype=DTYPE) * (
+        sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s
+    )
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
     alpha = 1 * dt
     cell_alpha = 10 * dt
     b_tau = 30 * dt
@@ -199,7 +203,7 @@ def test_npt_langevin_isotropic(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     temperatures_tensor = torch.stack(temperatures)
     energies_tensor = torch.stack(energies)
@@ -209,7 +213,7 @@ def test_npt_langevin_isotropic(
 
     mean_temps = torch.mean(temperatures_tensor, dim=0)
     for mean_temp in mean_temps:
-        assert abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
+        assert abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 150.0
 
     for traj in energies_list:
         energy_std = torch.tensor(traj).std()
@@ -224,8 +228,10 @@ def test_npt_langevin_multi_kt(
 ):
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor([300, 10_000], dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor([300, 10_000], dtype=DTYPE) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(0, dtype=DTYPE) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
     alpha = 40 * dt
     cell_alpha = alpha
     b_tau = 1 / (1000 * dt)
@@ -259,7 +265,7 @@ def test_npt_langevin_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -274,13 +280,13 @@ def test_npt_langevin_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / (bc.k_B / bc.e), rtol=0.5)
 
 
 def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 100
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=DTYPE) * (bc.k_B / bc.e)
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -295,7 +301,7 @@ def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -312,7 +318,7 @@ def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -335,7 +341,7 @@ def test_nvt_langevin_multi_kt(
 ):
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor([300, 10_000], dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor([300, 10_000], dtype=DTYPE) * (bc.k_B / bc.e)
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -350,7 +356,7 @@ def test_nvt_langevin_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -365,14 +371,14 @@ def test_nvt_langevin_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / (bc.k_B / bc.e), rtol=0.5)
 
 
 def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=dtype) * (bc.k_B / bc.e)
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -395,7 +401,7 @@ def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
         invariants.append(ts.nvt_nose_hoover_invariant(state, kT))
 
     # Convert temperatures list to tensor
@@ -419,7 +425,7 @@ def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -454,7 +460,7 @@ def test_nvt_nose_hoover_multi_equivalent_to_single(
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=dtype) * (bc.k_B / bc.e)
 
     final_temperatures = []
     initial_momenta = []
@@ -476,7 +482,7 @@ def test_nvt_nose_hoover_multi_equivalent_to_single(
         temp = ts.calc_kT(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
-        final_temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        final_temperatures.append(temp / (bc.k_B / bc.e))
 
     initial_momenta_tensor = torch.concat(initial_momenta)
     final_temperatures = torch.concat(final_temperatures)
@@ -496,7 +502,7 @@ def test_nvt_nose_hoover_multi_equivalent_to_single(
         masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
 
-    assert torch.allclose(final_temperatures, temp / BOLTZMANN_CONSTANT_EV_PER_K)
+    assert torch.allclose(final_temperatures, temp / (bc.k_B / bc.e))
 
 
 def test_nvt_nose_hoover_multi_kt(
@@ -505,7 +511,7 @@ def test_nvt_nose_hoover_multi_kt(
     dtype = torch.float64
     n_steps = 200
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor([300, 10_000], dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor([300, 10_000], dtype=dtype) * (bc.k_B / bc.e)
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -523,7 +529,7 @@ def test_nvt_nose_hoover_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
         invariants.append(ts.nvt_nose_hoover_invariant(state, kT))
 
     # Convert temperatures list to tensor
@@ -541,7 +547,7 @@ def test_nvt_nose_hoover_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / (bc.k_B / bc.e), rtol=0.5)
 
     # Check invariant conservation for each system
     for traj_idx in range(invariants_tensor.shape[1]):
@@ -555,7 +561,7 @@ def test_nvt_nose_hoover_multi_kt(
 def test_nvt_vrescale(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 100
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=DTYPE) * (bc.k_B / bc.e)
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -570,7 +576,7 @@ def test_nvt_vrescale(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -587,7 +593,7 @@ def test_nvt_vrescale(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -610,8 +616,10 @@ def test_npt_crescale_triclinic(
 ) -> None:
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
     tau_p = torch.tensor(0.1, dtype=DTYPE)
     isothermal_compressibility = torch.tensor(1e-4, dtype=DTYPE)
 
@@ -643,7 +651,7 @@ def test_npt_crescale_triclinic(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -660,7 +668,7 @@ def test_npt_crescale_triclinic(
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 150.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -684,13 +692,13 @@ def test_npt_crescale_triclinic_shear(
     """Test anisotropic crescale with off-diagonal (shear) external stress."""
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
     tau_p = torch.tensor(0.1, dtype=DTYPE)
     isothermal_compressibility = torch.tensor(1e-4, dtype=DTYPE)
 
     # Full 3x3 external pressure tensor with shear components
-    p_hydro = 10.0 * BAR_TO_EV_PER_ANGSTROM3
-    shear = 1.0 * BAR_TO_EV_PER_ANGSTROM3
+    p_hydro = 10.0 * (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e)
+    shear = 1.0 * (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e)
     external_pressure = torch.tensor(
         [
             [p_hydro, shear, 0.0],
@@ -733,7 +741,7 @@ def test_npt_crescale_triclinic_shear(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     temperatures_tensor = torch.stack(temperatures)
     energies_tensor = torch.stack(energies)
@@ -744,7 +752,7 @@ def test_npt_crescale_triclinic_shear(
     # Check temperature is roughly maintained
     mean_temps = torch.mean(temperatures_tensor, dim=0)
     for mean_temp in mean_temps:
-        assert abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
+        assert abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 150.0
 
     # Check energy is stable
     for traj in energies_tensor.T:
@@ -768,8 +776,10 @@ def test_npt_crescale_isotropic(
 ) -> None:
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
     tau_p = torch.tensor(0.1, dtype=DTYPE)
     isothermal_compressibility = torch.tensor(1e-4, dtype=DTYPE)
 
@@ -801,7 +811,7 @@ def test_npt_crescale_isotropic(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -818,7 +828,7 @@ def test_npt_crescale_isotropic(
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 150.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -840,8 +850,10 @@ def test_npt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(0.0, dtype=dtype) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor(300, dtype=dtype) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(0.0, dtype=dtype) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -869,7 +881,7 @@ def test_npt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
         invariants.append(
             ts.npt_nose_hoover_isotropic_invariant(state, kT, external_pressure)
         )
@@ -895,7 +907,7 @@ def test_npt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
+            abs(mean_temp - kT.item() / (bc.k_B / bc.e)) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory (NPT allows energy fluctuations)
@@ -929,16 +941,16 @@ def test_npt_nose_hoover_step_accepts_float_inputs(
         state=ar_double_sim_state,
         model=lj_model,
         dt=0.001,
-        kT=300 * BOLTZMANN_CONSTANT_EV_PER_K,
-        external_pressure=0.0 * BAR_TO_EV_PER_ANGSTROM3,
+        kT=300 * (bc.k_B / bc.e),
+        external_pressure=0.0 * (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e),
     )
 
     next_state = ts.npt_nose_hoover_isotropic_step(
         state=state,
         model=lj_model,
         dt=0.001,
-        kT=300 * BOLTZMANN_CONSTANT_EV_PER_K,
-        external_pressure=0.0 * BAR_TO_EV_PER_ANGSTROM3,
+        kT=300 * (bc.k_B / bc.e),
+        external_pressure=0.0 * (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e),
     )
     assert next_state.positions.shape == state.positions.shape
     assert next_state.momenta.shape == state.momenta.shape
@@ -953,8 +965,10 @@ def test_npt_nose_hoover_multi_equivalent_to_single(
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(0.0, dtype=dtype) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor(300, dtype=dtype) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(0.0, dtype=dtype) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
 
     final_temperatures = []
     initial_momenta = []
@@ -983,7 +997,7 @@ def test_npt_nose_hoover_multi_equivalent_to_single(
         temp = ts.calc_kT(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
-        final_temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        final_temperatures.append(temp / (bc.k_B / bc.e))
 
     initial_momenta_tensor = torch.concat(initial_momenta)
     final_temperatures = torch.concat(final_temperatures)
@@ -1010,7 +1024,7 @@ def test_npt_nose_hoover_multi_equivalent_to_single(
         masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
 
-    assert torch.allclose(final_temperatures, temp / BOLTZMANN_CONSTANT_EV_PER_K)
+    assert torch.allclose(final_temperatures, temp / (bc.k_B / bc.e))
 
 
 def test_npt_nose_hoover_multi_kt(
@@ -1019,8 +1033,10 @@ def test_npt_nose_hoover_multi_kt(
     dtype = torch.float64
     n_steps = 200
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor([300, 10_000], dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(0.0, dtype=dtype) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor([300, 10_000], dtype=dtype) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(0.0, dtype=dtype) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -1048,7 +1064,7 @@ def test_npt_nose_hoover_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
+        temperatures.append(temp / (bc.k_B / bc.e))
         invariants.append(
             ts.npt_nose_hoover_isotropic_invariant(state, kT, external_pressure)
         )
@@ -1068,7 +1084,7 @@ def test_npt_nose_hoover_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / (bc.k_B / bc.e), rtol=0.5)
 
     # Check invariant conservation for each system
     for traj_idx in range(invariants_tensor.shape[1]):
@@ -1082,7 +1098,7 @@ def test_npt_nose_hoover_multi_kt(
 def test_nve(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 100
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -1126,7 +1142,7 @@ def test_compare_single_vs_batched_integrators(
     final_states = {}
     for state_name, state in initial_states.items():
         # Initialize integrator
-        kT = torch.tensor(100.0) * BOLTZMANN_CONSTANT_EV_PER_K
+        kT = torch.tensor(100.0) * (bc.k_B / bc.e)
         dt = torch.tensor(0.001)  # Small timestep for stability
 
         # Initialize momenta (even if zero) and get forces
@@ -1202,7 +1218,7 @@ def test_nvt_langevin_reproducibility(
     """Two runs with the same prng seed must produce identical trajectories."""
     n_steps = 10
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    kT = torch.tensor(300, dtype=DTYPE) * (bc.k_B / bc.e)
 
     def _run(seed: int) -> tuple[torch.Tensor, torch.Tensor]:
         ar_double_sim_state.rng = seed
@@ -1229,8 +1245,10 @@ def test_npt_langevin_reproducibility(
     """Two runs with the same seed must produce identical NPT Langevin trajectories."""
     n_steps = 20
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
-    external_pressure = torch.tensor(10, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
+    kT = torch.tensor(300.0, dtype=DTYPE) * (bc.k_B / bc.e)
+    external_pressure = torch.tensor(10, dtype=DTYPE) * (
+        uc.bar_to_pa * uc.Ang3_to_met3 / bc.e
+    )
     alpha = 40 * dt
     cell_alpha = alpha
     b_tau = dt  # make this very small to ensure the barostat is active

--- a/tests/test_integrators.py
+++ b/tests/test_integrators.py
@@ -7,7 +7,11 @@ from torch_sim.integrators import initialize_momenta
 from torch_sim.integrators.npt import _npt_langevin_anisotropic_compute_cell_force
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.state import coerce_prng
-from torch_sim.units import MetalUnits
+from torch_sim.units import (
+    BAR_TO_EV_PER_ANGSTROM3,
+    BOLTZMANN_CONSTANT_EV_PER_K,
+    PS_TO_INTERNAL_TIME,
+)
 
 
 def test_initialize_momenta_basic():
@@ -85,8 +89,8 @@ def test_npt_langevin(
 ) -> None:
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * MetalUnits.pressure
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
     alpha = 40 * dt
     cell_alpha = alpha
     b_tau = 1 / (1000 * dt)
@@ -120,7 +124,7 @@ def test_npt_langevin(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -137,7 +141,7 @@ def test_npt_langevin(
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 150.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -159,9 +163,9 @@ def test_npt_langevin_isotropic(
     ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel
 ) -> None:
     n_steps = 200
-    dt = torch.tensor(0.001, dtype=DTYPE) * MetalUnits.time
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * MetalUnits.pressure
+    dt = torch.tensor(0.001, dtype=DTYPE) * PS_TO_INTERNAL_TIME
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
     alpha = 1 * dt
     cell_alpha = 10 * dt
     b_tau = 30 * dt
@@ -195,7 +199,7 @@ def test_npt_langevin_isotropic(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     temperatures_tensor = torch.stack(temperatures)
     energies_tensor = torch.stack(energies)
@@ -205,7 +209,7 @@ def test_npt_langevin_isotropic(
 
     mean_temps = torch.mean(temperatures_tensor, dim=0)
     for mean_temp in mean_temps:
-        assert abs(mean_temp - kT.item() / MetalUnits.temperature) < 150.0
+        assert abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
 
     for traj in energies_list:
         energy_std = torch.tensor(traj).std()
@@ -220,8 +224,8 @@ def test_npt_langevin_multi_kt(
 ):
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor([300, 10_000], dtype=DTYPE) * MetalUnits.temperature
-    external_pressure = torch.tensor(0, dtype=DTYPE) * MetalUnits.pressure
+    kT = torch.tensor([300, 10_000], dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
     alpha = 40 * dt
     cell_alpha = alpha
     b_tau = 1 / (1000 * dt)
@@ -255,7 +259,7 @@ def test_npt_langevin_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -270,13 +274,13 @@ def test_npt_langevin_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
 
 
 def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 100
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -291,7 +295,7 @@ def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -308,7 +312,7 @@ def test_nvt_langevin(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 100.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -331,7 +335,7 @@ def test_nvt_langevin_multi_kt(
 ):
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor([300, 10_000], dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor([300, 10_000], dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -346,7 +350,7 @@ def test_nvt_langevin_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -361,14 +365,14 @@ def test_nvt_langevin_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
 
 
 def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -391,7 +395,7 @@ def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
         invariants.append(ts.nvt_nose_hoover_invariant(state, kT))
 
     # Convert temperatures list to tensor
@@ -415,7 +419,7 @@ def test_nvt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 100.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -450,7 +454,7 @@ def test_nvt_nose_hoover_multi_equivalent_to_single(
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
 
     final_temperatures = []
     initial_momenta = []
@@ -472,7 +476,7 @@ def test_nvt_nose_hoover_multi_equivalent_to_single(
         temp = ts.calc_kT(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
-        final_temperatures.append(temp / MetalUnits.temperature)
+        final_temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     initial_momenta_tensor = torch.concat(initial_momenta)
     final_temperatures = torch.concat(final_temperatures)
@@ -492,7 +496,7 @@ def test_nvt_nose_hoover_multi_equivalent_to_single(
         masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
 
-    assert torch.allclose(final_temperatures, temp / MetalUnits.temperature)
+    assert torch.allclose(final_temperatures, temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
 
 def test_nvt_nose_hoover_multi_kt(
@@ -501,7 +505,7 @@ def test_nvt_nose_hoover_multi_kt(
     dtype = torch.float64
     n_steps = 200
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor([300, 10_000], dtype=dtype) * MetalUnits.temperature
+    kT = torch.tensor([300, 10_000], dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -519,7 +523,7 @@ def test_nvt_nose_hoover_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
         invariants.append(ts.nvt_nose_hoover_invariant(state, kT))
 
     # Convert temperatures list to tensor
@@ -537,7 +541,7 @@ def test_nvt_nose_hoover_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
 
     # Check invariant conservation for each system
     for traj_idx in range(invariants_tensor.shape[1]):
@@ -551,7 +555,7 @@ def test_nvt_nose_hoover_multi_kt(
 def test_nvt_vrescale(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 100
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -566,7 +570,7 @@ def test_nvt_vrescale(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -583,7 +587,7 @@ def test_nvt_vrescale(ar_double_sim_state: ts.SimState, lj_model: LennardJonesMo
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 100.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -606,8 +610,8 @@ def test_npt_crescale_triclinic(
 ) -> None:
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * MetalUnits.pressure
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
     tau_p = torch.tensor(0.1, dtype=DTYPE)
     isothermal_compressibility = torch.tensor(1e-4, dtype=DTYPE)
 
@@ -639,7 +643,7 @@ def test_npt_crescale_triclinic(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -656,7 +660,7 @@ def test_npt_crescale_triclinic(
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 150.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -680,13 +684,13 @@ def test_npt_crescale_triclinic_shear(
     """Test anisotropic crescale with off-diagonal (shear) external stress."""
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
     tau_p = torch.tensor(0.1, dtype=DTYPE)
     isothermal_compressibility = torch.tensor(1e-4, dtype=DTYPE)
 
     # Full 3x3 external pressure tensor with shear components
-    p_hydro = 10.0 * MetalUnits.pressure
-    shear = 1.0 * MetalUnits.pressure
+    p_hydro = 10.0 * BAR_TO_EV_PER_ANGSTROM3
+    shear = 1.0 * BAR_TO_EV_PER_ANGSTROM3
     external_pressure = torch.tensor(
         [
             [p_hydro, shear, 0.0],
@@ -729,7 +733,7 @@ def test_npt_crescale_triclinic_shear(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     temperatures_tensor = torch.stack(temperatures)
     energies_tensor = torch.stack(energies)
@@ -740,7 +744,7 @@ def test_npt_crescale_triclinic_shear(
     # Check temperature is roughly maintained
     mean_temps = torch.mean(temperatures_tensor, dim=0)
     for mean_temp in mean_temps:
-        assert abs(mean_temp - kT.item() / MetalUnits.temperature) < 150.0
+        assert abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
 
     # Check energy is stable
     for traj in energies_tensor.T:
@@ -764,8 +768,8 @@ def test_npt_crescale_isotropic(
 ) -> None:
     n_steps = 200
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
-    external_pressure = torch.tensor(10.0, dtype=DTYPE) * MetalUnits.pressure
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(10.0, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
     tau_p = torch.tensor(0.1, dtype=DTYPE)
     isothermal_compressibility = torch.tensor(1e-4, dtype=DTYPE)
 
@@ -797,7 +801,7 @@ def test_npt_crescale_isotropic(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     # Convert temperatures list to tensor
     temperatures_tensor = torch.stack(temperatures)
@@ -814,7 +818,7 @@ def test_npt_crescale_isotropic(
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 150.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 150.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory
@@ -836,8 +840,8 @@ def test_npt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * MetalUnits.temperature
-    external_pressure = torch.tensor(0.0, dtype=dtype) * MetalUnits.pressure
+    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(0.0, dtype=dtype) * BAR_TO_EV_PER_ANGSTROM3
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -865,7 +869,7 @@ def test_npt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
         invariants.append(
             ts.npt_nose_hoover_isotropic_invariant(state, kT, external_pressure)
         )
@@ -891,7 +895,7 @@ def test_npt_nose_hoover(ar_double_sim_state: ts.SimState, lj_model: LennardJone
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
     for mean_temp in mean_temps:
         assert (
-            abs(mean_temp - kT.item() / MetalUnits.temperature) < 100.0
+            abs(mean_temp - kT.item() / BOLTZMANN_CONSTANT_EV_PER_K) < 100.0
         )  # Allow for thermal fluctuations
 
     # Check energy is stable for each trajectory (NPT allows energy fluctuations)
@@ -925,16 +929,16 @@ def test_npt_nose_hoover_step_accepts_float_inputs(
         state=ar_double_sim_state,
         model=lj_model,
         dt=0.001,
-        kT=300 * MetalUnits.temperature,
-        external_pressure=0.0 * MetalUnits.pressure,
+        kT=300 * BOLTZMANN_CONSTANT_EV_PER_K,
+        external_pressure=0.0 * BAR_TO_EV_PER_ANGSTROM3,
     )
 
     next_state = ts.npt_nose_hoover_isotropic_step(
         state=state,
         model=lj_model,
         dt=0.001,
-        kT=300 * MetalUnits.temperature,
-        external_pressure=0.0 * MetalUnits.pressure,
+        kT=300 * BOLTZMANN_CONSTANT_EV_PER_K,
+        external_pressure=0.0 * BAR_TO_EV_PER_ANGSTROM3,
     )
     assert next_state.positions.shape == state.positions.shape
     assert next_state.momenta.shape == state.momenta.shape
@@ -949,8 +953,8 @@ def test_npt_nose_hoover_multi_equivalent_to_single(
     dtype = torch.float64
     n_steps = 100
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor(300, dtype=dtype) * MetalUnits.temperature
-    external_pressure = torch.tensor(0.0, dtype=dtype) * MetalUnits.pressure
+    kT = torch.tensor(300, dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(0.0, dtype=dtype) * BAR_TO_EV_PER_ANGSTROM3
 
     final_temperatures = []
     initial_momenta = []
@@ -979,7 +983,7 @@ def test_npt_nose_hoover_multi_equivalent_to_single(
         temp = ts.calc_kT(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
-        final_temperatures.append(temp / MetalUnits.temperature)
+        final_temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
     initial_momenta_tensor = torch.concat(initial_momenta)
     final_temperatures = torch.concat(final_temperatures)
@@ -1006,7 +1010,7 @@ def test_npt_nose_hoover_multi_equivalent_to_single(
         masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
     )
 
-    assert torch.allclose(final_temperatures, temp / MetalUnits.temperature)
+    assert torch.allclose(final_temperatures, temp / BOLTZMANN_CONSTANT_EV_PER_K)
 
 
 def test_npt_nose_hoover_multi_kt(
@@ -1015,8 +1019,8 @@ def test_npt_nose_hoover_multi_kt(
     dtype = torch.float64
     n_steps = 200
     dt = torch.tensor(0.001, dtype=dtype)
-    kT = torch.tensor([300, 10_000], dtype=dtype) * MetalUnits.temperature
-    external_pressure = torch.tensor(0.0, dtype=dtype) * MetalUnits.pressure
+    kT = torch.tensor([300, 10_000], dtype=dtype) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(0.0, dtype=dtype) * BAR_TO_EV_PER_ANGSTROM3
 
     # Run dynamics for several steps
     ar_double_sim_state.rng = 42
@@ -1044,7 +1048,7 @@ def test_npt_nose_hoover_multi_kt(
             masses=state.masses, momenta=state.momenta, system_idx=state.system_idx
         )
         energies.append(state.energy)
-        temperatures.append(temp / MetalUnits.temperature)
+        temperatures.append(temp / BOLTZMANN_CONSTANT_EV_PER_K)
         invariants.append(
             ts.npt_nose_hoover_isotropic_invariant(state, kT, external_pressure)
         )
@@ -1064,7 +1068,7 @@ def test_npt_nose_hoover_multi_kt(
 
     # Check temperature is roughly maintained for each trajectory
     mean_temps = torch.mean(temperatures_tensor, dim=0)  # Mean temp for each trajectory
-    assert torch.allclose(mean_temps, kT / MetalUnits.temperature, rtol=0.5)
+    assert torch.allclose(mean_temps, kT / BOLTZMANN_CONSTANT_EV_PER_K, rtol=0.5)
 
     # Check invariant conservation for each system
     for traj_idx in range(invariants_tensor.shape[1]):
@@ -1078,7 +1082,7 @@ def test_npt_nose_hoover_multi_kt(
 def test_nve(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 100
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Initialize integrator
     ar_double_sim_state.rng = 42
@@ -1122,7 +1126,7 @@ def test_compare_single_vs_batched_integrators(
     final_states = {}
     for state_name, state in initial_states.items():
         # Initialize integrator
-        kT = torch.tensor(100.0) * MetalUnits.temperature
+        kT = torch.tensor(100.0) * BOLTZMANN_CONSTANT_EV_PER_K
         dt = torch.tensor(0.001)  # Small timestep for stability
 
         # Initialize momenta (even if zero) and get forces
@@ -1198,7 +1202,7 @@ def test_nvt_langevin_reproducibility(
     """Two runs with the same prng seed must produce identical trajectories."""
     n_steps = 10
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300, dtype=DTYPE) * MetalUnits.temperature
+    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     def _run(seed: int) -> tuple[torch.Tensor, torch.Tensor]:
         ar_double_sim_state.rng = seed
@@ -1225,8 +1229,8 @@ def test_npt_langevin_reproducibility(
     """Two runs with the same seed must produce identical NPT Langevin trajectories."""
     n_steps = 20
     dt = torch.tensor(0.001, dtype=DTYPE)
-    kT = torch.tensor(300.0, dtype=DTYPE) * MetalUnits.temperature
-    external_pressure = torch.tensor(10, dtype=DTYPE) * MetalUnits.pressure
+    kT = torch.tensor(300.0, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    external_pressure = torch.tensor(10, dtype=DTYPE) * BAR_TO_EV_PER_ANGSTROM3
     alpha = 40 * dt
     cell_alpha = alpha
     b_tau = dt  # make this very small to ensure the barostat is active

--- a/tests/test_physical_validation.py
+++ b/tests/test_physical_validation.py
@@ -37,6 +37,7 @@ Clean up saved data programmatically:
 
 import shutil
 import warnings
+from math import sqrt
 from pathlib import Path
 
 import numpy as np
@@ -48,11 +49,7 @@ from numpy.typing import NDArray
 import torch_sim as ts
 from torch_sim.integrators.npt import npt_crescale_triclinic_average_step
 from torch_sim.models.lennard_jones import LennardJonesModel
-from torch_sim.units import (
-    BAR_TO_EV_PER_ANGSTROM3,
-    BOLTZMANN_CONSTANT_EV_PER_K,
-    PS_TO_INTERNAL_TIME,
-)
+from torch_sim.units import bc, uc
 
 
 physical_validation = pytest.importorskip("physical_validation")
@@ -88,7 +85,7 @@ TEMPERATURES = [58.3, 60.0]
 EXTERNAL_PRESSURE = 0.0
 PRESSURE_SWEEP_TEMP = 60.0
 PRESSURE_SWEEP_BAR = 90.0
-PRESSURE_SWEEP_EVA3 = PRESSURE_SWEEP_BAR * float(BAR_TO_EV_PER_ANGSTROM3)
+PRESSURE_SWEEP_EVA3 = PRESSURE_SWEEP_BAR * float(uc.bar_to_pa * uc.Ang3_to_met3 / bc.e)
 
 # Physical validation thresholds (in sigma units)
 KE_SIGMA_WARNING = 2.0
@@ -119,11 +116,11 @@ def clean_validation_data() -> None:
 # Internal helpers
 # ---------------------------------------------------------------------------
 def _to_kt(temperature_K: float) -> float:
-    return temperature_K * float(BOLTZMANN_CONSTANT_EV_PER_K)
+    return temperature_K * float(bc.k_B / bc.e)
 
 
 def _to_dt(timestep_ps: float) -> float:
-    return timestep_ps * float(PS_TO_INTERNAL_TIME)
+    return timestep_ps * float(sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s)
 
 
 def _save_run_data(data: RunData, label: str) -> Path:
@@ -144,7 +141,7 @@ def _get_plot_path(request: pytest.FixtureRequest, name: str) -> str | None:
 
 def _pressure_to_bar(p_eva3: float) -> float:
     """Convert eV/Ang^3 to bar."""
-    return p_eva3 / float(BAR_TO_EV_PER_ANGSTROM3)
+    return p_eva3 / float(uc.bar_to_pa * uc.Ang3_to_met3 / bc.e)
 
 
 # ---------------------------------------------------------------------------
@@ -153,7 +150,7 @@ def _pressure_to_bar(p_eva3: float) -> float:
 def _make_unit_data() -> physical_validation.data.UnitData:
     """Create UnitData for torch-sim's internal unit convention."""
     return physical_validation.data.UnitData(
-        kb=float(BOLTZMANN_CONSTANT_EV_PER_K),  # k_B in eV/K = 8.617e-5
+        kb=float(bc.k_B / bc.e),  # k_B in eV/K = 8.617e-5
         energy_str="eV",
         energy_conversion=96.485,  # Convert to kJ/mol
         length_str="Ang",
@@ -325,7 +322,7 @@ def _run_npt(  # noqa: C901
             kT=kT,
             dt=dt,
             tau_p=3 * dt,
-            isothermal_compressibility=1e-6 / BAR_TO_EV_PER_ANGSTROM3,
+            isothermal_compressibility=1e-6 / (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e),
         )
     else:
         msg = f"Unknown NPT integrator: {integrator_name}"

--- a/tests/test_physical_validation.py
+++ b/tests/test_physical_validation.py
@@ -48,7 +48,11 @@ from numpy.typing import NDArray
 import torch_sim as ts
 from torch_sim.integrators.npt import npt_crescale_triclinic_average_step
 from torch_sim.models.lennard_jones import LennardJonesModel
-from torch_sim.units import MetalUnits
+from torch_sim.units import (
+    BAR_TO_EV_PER_ANGSTROM3,
+    BOLTZMANN_CONSTANT_EV_PER_K,
+    PS_TO_INTERNAL_TIME,
+)
 
 
 physical_validation = pytest.importorskip("physical_validation")
@@ -84,7 +88,7 @@ TEMPERATURES = [58.3, 60.0]
 EXTERNAL_PRESSURE = 0.0
 PRESSURE_SWEEP_TEMP = 60.0
 PRESSURE_SWEEP_BAR = 90.0
-PRESSURE_SWEEP_EVA3 = PRESSURE_SWEEP_BAR * float(MetalUnits.pressure)
+PRESSURE_SWEEP_EVA3 = PRESSURE_SWEEP_BAR * float(BAR_TO_EV_PER_ANGSTROM3)
 
 # Physical validation thresholds (in sigma units)
 KE_SIGMA_WARNING = 2.0
@@ -115,11 +119,11 @@ def clean_validation_data() -> None:
 # Internal helpers
 # ---------------------------------------------------------------------------
 def _to_kt(temperature_K: float) -> float:
-    return temperature_K * float(MetalUnits.temperature)
+    return temperature_K * float(BOLTZMANN_CONSTANT_EV_PER_K)
 
 
 def _to_dt(timestep_ps: float) -> float:
-    return timestep_ps * float(MetalUnits.time)
+    return timestep_ps * float(PS_TO_INTERNAL_TIME)
 
 
 def _save_run_data(data: RunData, label: str) -> Path:
@@ -140,16 +144,16 @@ def _get_plot_path(request: pytest.FixtureRequest, name: str) -> str | None:
 
 def _pressure_to_bar(p_eva3: float) -> float:
     """Convert eV/Ang^3 to bar."""
-    return p_eva3 / float(MetalUnits.pressure)
+    return p_eva3 / float(BAR_TO_EV_PER_ANGSTROM3)
 
 
 # ---------------------------------------------------------------------------
 # Helpers: unit data, model, structure
 # ---------------------------------------------------------------------------
 def _make_unit_data() -> physical_validation.data.UnitData:
-    """Create UnitData for torch-sim's MetalUnits system."""
+    """Create UnitData for torch-sim's internal unit convention."""
     return physical_validation.data.UnitData(
-        kb=float(MetalUnits.temperature),  # k_B in eV/K = 8.617e-5
+        kb=float(BOLTZMANN_CONSTANT_EV_PER_K),  # k_B in eV/K = 8.617e-5
         energy_str="eV",
         energy_conversion=96.485,  # Convert to kJ/mol
         length_str="Ang",
@@ -321,7 +325,7 @@ def _run_npt(  # noqa: C901
             kT=kT,
             dt=dt,
             tau_p=3 * dt,
-            isothermal_compressibility=1e-6 / MetalUnits.pressure,
+            isothermal_compressibility=1e-6 / BAR_TO_EV_PER_ANGSTROM3,
         )
     else:
         msg = f"Unknown NPT integrator: {integrator_name}"

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -12,7 +12,7 @@ from torch_sim.quantities import (
     calc_kT,
     calc_temperature,
 )
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
 
 
 class TestHeatFlux:
@@ -275,4 +275,4 @@ def test_calc_temperature(single_system_data: dict[str, Tensor]) -> None:
         masses=single_system_data["masses"],
         velocities=single_system_data["velocities"],
     )
-    assert torch.allclose(temp, kt / MetalUnits.temperature)
+    assert torch.allclose(temp, kt / BOLTZMANN_CONSTANT_EV_PER_K)

--- a/tests/test_quantities.py
+++ b/tests/test_quantities.py
@@ -12,7 +12,7 @@ from torch_sim.quantities import (
     calc_kT,
     calc_temperature,
 )
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
+from torch_sim.units import bc
 
 
 class TestHeatFlux:
@@ -275,4 +275,4 @@ def test_calc_temperature(single_system_data: dict[str, Tensor]) -> None:
         masses=single_system_data["masses"],
         velocities=single_system_data["velocities"],
     )
-    assert torch.allclose(temp, kt / BOLTZMANN_CONSTANT_EV_PER_K)
+    assert torch.allclose(temp, kt / (bc.k_B / bc.e))

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1,4 +1,3 @@
-import inspect
 from collections.abc import Callable
 from pathlib import Path
 
@@ -14,7 +13,6 @@ from torch_sim.integrators.md import MDState
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.state import SimState
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
-from torch_sim.units import BAR_TO_EV_PER_ANGSTROM3, PS_TO_INTERNAL_TIME
 
 
 def test_integrate_nve(
@@ -108,75 +106,6 @@ def test_integrate_double_nvt(
     assert isinstance(final_state, SimState)
     assert final_state.n_atoms == 64
     assert not torch.isnan(final_state.energy).any()
-
-
-def test_integrate_converts_thermostat_tau(
-    ar_supercell_sim_state: SimState, lj_model: LennardJonesModel
-) -> None:
-    """High-level relaxation times use the same ps convention as timestep."""
-    tau = 0.1
-    final_state = ts.integrate(
-        system=ar_supercell_sim_state,
-        model=lj_model,
-        integrator=ts.Integrator.nvt_nose_hoover,
-        n_steps=1,
-        temperature=100.0,
-        timestep=0.002,
-        init_kwargs={"tau": tau},
-    )
-
-    expected = tau * PS_TO_INTERNAL_TIME
-    assert torch.allclose(
-        final_state.chain.tau, torch.full_like(final_state.chain.tau, expected)
-    )
-
-
-@pytest.mark.parametrize(
-    ("integrator", "channel", "key", "factor"),
-    [
-        (ts.Integrator.nvt_nose_hoover, "init", "tau", PS_TO_INTERNAL_TIME),
-        (ts.Integrator.nvt_langevin, "step", "gamma", 1 / PS_TO_INTERNAL_TIME),
-        (
-            ts.Integrator.npt_langevin_isotropic,
-            "step",
-            "external_pressure",
-            BAR_TO_EV_PER_ANGSTROM3,
-        ),
-        (
-            ts.Integrator.npt_crescale_isotropic,
-            "init",
-            "isothermal_compressibility",
-            1 / BAR_TO_EV_PER_ANGSTROM3,
-        ),
-    ],
-)
-def test_convert_integrator_kwargs(
-    integrator: ts.Integrator, channel: str, key: str, factor: float
-) -> None:
-    """Boundary conversion handles each supported physical dimension."""
-    init_kwargs = {key: 2.0} if channel == "init" else {}
-    step_kwargs = {key: 2.0} if channel == "step" else {}
-
-    ts.runners._convert_integrator_kwargs(  # noqa: SLF001
-        integrator, init_kwargs, step_kwargs
-    )
-
-    converted = init_kwargs if channel == "init" else step_kwargs
-    assert converted[key] == pytest.approx(2.0 * factor)
-
-
-def test_integrator_kwarg_conversion_maps_match_signatures() -> None:
-    """Explicit conversion keys stay aligned with registered function signatures."""
-    channel_maps = {
-        "init": ts.runners._INTEGRATOR_INIT_KWARG_FACTORS,  # noqa: SLF001
-        "step": ts.runners._INTEGRATOR_STEP_KWARG_FACTORS,  # noqa: SLF001
-    }
-    for channel, conversion_map in channel_maps.items():
-        function_index = 0 if channel == "init" else 1
-        for integrator, conversions in conversion_map.items():
-            function = ts.integrators.INTEGRATOR_REGISTRY[integrator][function_index]
-            parameters = inspect.signature(function).parameters
-            assert conversions.keys() <= parameters.keys()
 
 
 def test_integrate_double_nvt_multiple_temperatures(
@@ -802,8 +731,7 @@ def test_static_with_autobatcher_and_reporting(
     tmp_path: Path,
 ) -> None:
     """Test static calculation with autobatcher, trajectory reporting, and robust
-    reordering.
-    """
+    reordering."""
     from ase.build import bulk
 
     # 1. Create diverse SimState objects for robust binning test

--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -1,3 +1,4 @@
+import inspect
 from collections.abc import Callable
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from torch_sim.integrators.md import MDState
 from torch_sim.models.lennard_jones import LennardJonesModel
 from torch_sim.state import SimState
 from torch_sim.trajectory import TorchSimTrajectory, TrajectoryReporter
+from torch_sim.units import BAR_TO_EV_PER_ANGSTROM3, PS_TO_INTERNAL_TIME
 
 
 def test_integrate_nve(
@@ -106,6 +108,75 @@ def test_integrate_double_nvt(
     assert isinstance(final_state, SimState)
     assert final_state.n_atoms == 64
     assert not torch.isnan(final_state.energy).any()
+
+
+def test_integrate_converts_thermostat_tau(
+    ar_supercell_sim_state: SimState, lj_model: LennardJonesModel
+) -> None:
+    """High-level relaxation times use the same ps convention as timestep."""
+    tau = 0.1
+    final_state = ts.integrate(
+        system=ar_supercell_sim_state,
+        model=lj_model,
+        integrator=ts.Integrator.nvt_nose_hoover,
+        n_steps=1,
+        temperature=100.0,
+        timestep=0.002,
+        init_kwargs={"tau": tau},
+    )
+
+    expected = tau * PS_TO_INTERNAL_TIME
+    assert torch.allclose(
+        final_state.chain.tau, torch.full_like(final_state.chain.tau, expected)
+    )
+
+
+@pytest.mark.parametrize(
+    ("integrator", "channel", "key", "factor"),
+    [
+        (ts.Integrator.nvt_nose_hoover, "init", "tau", PS_TO_INTERNAL_TIME),
+        (ts.Integrator.nvt_langevin, "step", "gamma", 1 / PS_TO_INTERNAL_TIME),
+        (
+            ts.Integrator.npt_langevin_isotropic,
+            "step",
+            "external_pressure",
+            BAR_TO_EV_PER_ANGSTROM3,
+        ),
+        (
+            ts.Integrator.npt_crescale_isotropic,
+            "init",
+            "isothermal_compressibility",
+            1 / BAR_TO_EV_PER_ANGSTROM3,
+        ),
+    ],
+)
+def test_convert_integrator_kwargs(
+    integrator: ts.Integrator, channel: str, key: str, factor: float
+) -> None:
+    """Boundary conversion handles each supported physical dimension."""
+    init_kwargs = {key: 2.0} if channel == "init" else {}
+    step_kwargs = {key: 2.0} if channel == "step" else {}
+
+    ts.runners._convert_integrator_kwargs(  # noqa: SLF001
+        integrator, init_kwargs, step_kwargs
+    )
+
+    converted = init_kwargs if channel == "init" else step_kwargs
+    assert converted[key] == pytest.approx(2.0 * factor)
+
+
+def test_integrator_kwarg_conversion_maps_match_signatures() -> None:
+    """Explicit conversion keys stay aligned with registered function signatures."""
+    channel_maps = {
+        "init": ts.runners._INTEGRATOR_INIT_KWARG_FACTORS,  # noqa: SLF001
+        "step": ts.runners._INTEGRATOR_STEP_KWARG_FACTORS,  # noqa: SLF001
+    }
+    for channel, conversion_map in channel_maps.items():
+        function_index = 0 if channel == "init" else 1
+        for integrator, conversions in conversion_map.items():
+            function = ts.integrators.INTEGRATOR_REGISTRY[integrator][function_index]
+            parameters = inspect.signature(function).parameters
+            assert conversions.keys() <= parameters.keys()
 
 
 def test_integrate_double_nvt_multiple_temperatures(
@@ -731,7 +802,8 @@ def test_static_with_autobatcher_and_reporting(
     tmp_path: Path,
 ) -> None:
     """Test static calculation with autobatcher, trajectory reporting, and robust
-    reordering."""
+    reordering.
+    """
     from ase.build import bulk
 
     # 1. Create diverse SimState objects for robust binning test

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -12,7 +12,7 @@ import torch_sim as ts
 import torch_sim.transforms as tst
 from tests.conftest import DEVICE, DTYPE
 from torch_sim.models.lennard_jones import LennardJonesModel
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
 
 
 def test_inverse_box_scalar() -> None:
@@ -1396,8 +1396,8 @@ def test_build_linked_cell_neighborhood_basic() -> None:
 
 def test_unwrap_positions(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 50
-    dt = torch.tensor(0.001, dtype=DTYPE) * MetalUnits.time
-    kT = torch.tensor(300, dtype=DTYPE) * MetalUnits.temperature
+    dt = torch.tensor(0.001, dtype=DTYPE) * PS_TO_INTERNAL_TIME
+    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
 
     # Same cell
     state = ts.nvt_langevin_init(state=ar_double_sim_state, model=lj_model, kT=kT)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,5 +1,6 @@
 # ruff: noqa: PT011
 import itertools
+from math import sqrt
 
 import numpy as np
 import pytest
@@ -12,7 +13,7 @@ import torch_sim as ts
 import torch_sim.transforms as tst
 from tests.conftest import DEVICE, DTYPE
 from torch_sim.models.lennard_jones import LennardJonesModel
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
+from torch_sim.units import bc, uc
 
 
 def test_inverse_box_scalar() -> None:
@@ -1396,8 +1397,10 @@ def test_build_linked_cell_neighborhood_basic() -> None:
 
 def test_unwrap_positions(ar_double_sim_state: ts.SimState, lj_model: LennardJonesModel):
     n_steps = 50
-    dt = torch.tensor(0.001, dtype=DTYPE) * PS_TO_INTERNAL_TIME
-    kT = torch.tensor(300, dtype=DTYPE) * BOLTZMANN_CONSTANT_EV_PER_K
+    dt = torch.tensor(0.001, dtype=DTYPE) * (
+        sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s
+    )
+    kT = torch.tensor(300, dtype=DTYPE) * (bc.k_B / bc.e)
 
     # Same cell
     state = ts.nvt_langevin_init(state=ar_double_sim_state, model=lj_model, kT=kT)

--- a/torch_sim/integrators/__init__.py
+++ b/torch_sim/integrators/__init__.py
@@ -60,11 +60,11 @@ References:
 
 Examples:
     >>> import torch_sim as ts
-    >>> state = ts.nvt_langevin_init(initial_state, model, kT=300.0 * units.temperature)
+    >>> kT = 0.025852  # 300 K in eV
+    >>> dt = 0.098227  # 1 fs in the time unit coherent with eV, angstrom, and amu
+    >>> state = ts.nvt_langevin_init(initial_state, model, kT=kT)
     >>> for _ in range(1000):
-    ...     state = ts.nvt_langevin_step(
-    ...         state, model, dt=1e-3 * units.time, kT=300.0 * units.temperature
-    ...     )
+    ...     state = ts.nvt_langevin_step(state, model, dt=dt, kT=kT)
 
 Notes:
     All integrators support batched operations for efficient parallel simulation

--- a/torch_sim/integrators/md.py
+++ b/torch_sim/integrators/md.py
@@ -11,7 +11,7 @@ from torch_sim._duecredit import dcite
 from torch_sim.models.interface import ModelInterface
 from torch_sim.quantities import calc_kT
 from torch_sim.state import SimState
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
+from torch_sim.units import bc
 
 
 logger = logging.getLogger(__name__)
@@ -72,18 +72,13 @@ class MDState(SimState):
             constraint.adjust_momenta(self, new_momenta)
         self.momenta = new_momenta
 
-    def calc_temperature(
-        self, units: float = BOLTZMANN_CONSTANT_EV_PER_K
-    ) -> torch.Tensor:
+    def calc_temperature(self) -> torch.Tensor:
         """Calculate temperature from momenta, masses, and system indices.
 
-        Args:
-            units: Energy per temperature unit. Defaults to eV/K.
-
         Returns:
-            torch.Tensor: Calculated temperature
+            torch.Tensor: Calculated temperature in kelvin.
         """
-        return self.calc_kT() / units
+        return self.calc_kT() / (bc.k_B / bc.e)
 
     def calc_kT(self) -> torch.Tensor:  # noqa: N802
         """Calculate kT from momenta, masses, and system indices.

--- a/torch_sim/integrators/md.py
+++ b/torch_sim/integrators/md.py
@@ -11,7 +11,7 @@ from torch_sim._duecredit import dcite
 from torch_sim.models.interface import ModelInterface
 from torch_sim.quantities import calc_kT
 from torch_sim.state import SimState
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
 
 
 logger = logging.getLogger(__name__)
@@ -73,17 +73,17 @@ class MDState(SimState):
         self.momenta = new_momenta
 
     def calc_temperature(
-        self, units: MetalUnits = MetalUnits.temperature
+        self, units: float = BOLTZMANN_CONSTANT_EV_PER_K
     ) -> torch.Tensor:
         """Calculate temperature from momenta, masses, and system indices.
 
         Args:
-            units (MetalUnits): Units to return the temperature in
+            units: Energy per temperature unit. Defaults to eV/K.
 
         Returns:
             torch.Tensor: Calculated temperature
         """
-        return self.calc_kT() / units.temperature
+        return self.calc_kT() / units
 
     def calc_kT(self) -> torch.Tensor:  # noqa: N802
         """Calculate kT from momenta, masses, and system indices.

--- a/torch_sim/integrators/npt.py
+++ b/torch_sim/integrators/npt.py
@@ -21,7 +21,7 @@ from torch_sim.integrators.md import (
 from torch_sim.integrators.nvt import _vrescale_update
 from torch_sim.models.interface import ModelInterface
 from torch_sim.state import SimState
-from torch_sim.units import BAR_TO_EV_PER_ANGSTROM3
+from torch_sim.units import bc, uc
 
 
 logger = logging.getLogger(__name__)
@@ -2934,7 +2934,8 @@ def npt_crescale_init(
     # Set default values if not provided
     tau_p = torch.as_tensor(tau_p or 3 * dt, device=device, dtype=dtype)  # 5ps for dt=1fs
     isothermal_compressibility = torch.as_tensor(
-        isothermal_compressibility or 1e-6 / BAR_TO_EV_PER_ANGSTROM3,  # 1e-6 bar^-1
+        isothermal_compressibility
+        or 1e-6 / (uc.bar_to_pa * uc.Ang3_to_met3 / bc.e),  # 1e-6 bar^-1
         device=device,
         dtype=dtype,  # (eV/A^3)^-1
     )

--- a/torch_sim/integrators/npt.py
+++ b/torch_sim/integrators/npt.py
@@ -21,7 +21,7 @@ from torch_sim.integrators.md import (
 from torch_sim.integrators.nvt import _vrescale_update
 from torch_sim.models.interface import ModelInterface
 from torch_sim.state import SimState
-from torch_sim.units import MetalUnits
+from torch_sim.units import BAR_TO_EV_PER_ANGSTROM3
 
 
 logger = logging.getLogger(__name__)
@@ -2934,8 +2934,7 @@ def npt_crescale_init(
     # Set default values if not provided
     tau_p = torch.as_tensor(tau_p or 3 * dt, device=device, dtype=dtype)  # 5ps for dt=1fs
     isothermal_compressibility = torch.as_tensor(
-        isothermal_compressibility
-        or 1e-6 / MetalUnits.pressure,  # 1e-6 bar^-1 for metals
+        isothermal_compressibility or 1e-6 / BAR_TO_EV_PER_ANGSTROM3,  # 1e-6 bar^-1
         device=device,
         dtype=dtype,  # (eV/A^3)^-1
     )

--- a/torch_sim/models/dispersion.py
+++ b/torch_sim/models/dispersion.py
@@ -57,9 +57,9 @@ class D3DispersionModel(ModelInterface):
     """DFT-D3(BJ) dispersion correction as a :class:`ModelInterface`.
 
     Computes DFT-D3 energies, forces, and (optionally) stresses via the
-    ``nvalchemiops`` Warp GPU/CPU kernels.  All user-facing quantities are in
-    metal units (Angstrom / eV); unit conversion to and from atomic units
-    (Bohr / Hartree) is handled internally.
+    ``nvalchemiops`` Warp GPU/CPU kernels. User-facing distances are in angstrom
+    and energies are in eV; conversion to and from atomic units (Bohr / Hartree)
+    is handled internally.
 
     Functional-dependent BJ damping parameters (``a1``, ``a2``, ``s8``, ``s6``)
     can be looked up from the canonical parameter table:

--- a/torch_sim/models/electrostatics.py
+++ b/torch_sim/models/electrostatics.py
@@ -52,8 +52,8 @@ class DSFCoulombModel(ModelInterface):
     """Damped Shifted Force electrostatics as a :class:`ModelInterface`.
 
     Uses the ``nvalchemiops`` DSF kernel for O(N) electrostatic energy,
-    forces, and (optionally) stress.  All user-facing quantities are in
-    metal units (Angstrom / eV); the Coulomb constant ``ke`` is baked in.
+    forces, and (optionally) stress. User-facing distances are in angstrom and
+    energies are in eV; the Coulomb constant ``ke`` is baked in.
 
     Per-atom partial charges are read from ``state.partial_charges``.
 
@@ -157,8 +157,8 @@ class EwaldModel(ModelInterface):
     """Classical Ewald summation as a :class:`ModelInterface`.
 
     Uses the ``nvalchemiops`` Ewald kernel for exact periodic electrostatics.
-    Returns per-atom energies that are aggregated to per-system.  All
-    user-facing quantities are in metal units (Angstrom / eV).
+    Returns per-atom energies that are aggregated to per-system. User-facing
+    distances are in angstrom and energies are in eV.
 
     Per-atom partial charges are read from ``state.partial_charges``.
 
@@ -271,9 +271,8 @@ class PMEModel(ModelInterface):
     """Particle Mesh Ewald electrostatics as a :class:`ModelInterface`.
 
     Uses the ``nvalchemiops`` PME kernel for O(N log N) periodic
-    electrostatics.  Returns per-atom energies that are aggregated to
-    per-system.  All user-facing quantities are in metal units
-    (Angstrom / eV).
+    electrostatics. Returns per-atom energies that are aggregated to per-system.
+    User-facing distances are in angstrom and energies are in eV.
 
     Per-atom partial charges are read from ``state.partial_charges``.
 

--- a/torch_sim/monte_carlo.py
+++ b/torch_sim/monte_carlo.py
@@ -13,7 +13,7 @@ Examples:
     >>> import torch_sim as ts
     >>> mc_state = ts.swap_mc_init(model, initial_state, seed=42)
     >>> for _ in range(1000):
-    ...     mc_state = ts.swap_mc_step(model, mc_state, kT=0.1 * units.energy)
+    ...     mc_state = ts.swap_mc_step(model, mc_state, kT=0.1)  # eV
 """
 
 from dataclasses import dataclass, field

--- a/torch_sim/quantities.py
+++ b/torch_sim/quantities.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
+from torch_sim.units import bc
 
 
 if TYPE_CHECKING:
@@ -73,7 +73,6 @@ def calc_temperature(
     velocities: torch.Tensor | None = None,
     system_idx: torch.Tensor | None = None,
     dof_per_system: torch.Tensor | None = None,
-    units: float = BOLTZMANN_CONSTANT_EV_PER_K,
 ) -> torch.Tensor:
     """Calculate temperature from momenta/velocities and masses.
 
@@ -85,10 +84,8 @@ def calc_temperature(
         each particle
         dof_per_system (torch.Tensor | None): Optional tensor indicating
         degrees of freedom per system
-        units (object): Units to return the temperature in
-
     Returns:
-        torch.Tensor: Temperature value in specified units (default, K)
+        torch.Tensor: Temperature in kelvin.
     """
     kT = calc_kT(
         masses=masses,
@@ -97,7 +94,7 @@ def calc_temperature(
         system_idx=system_idx,
         dof_per_system=dof_per_system,
     )
-    return kT / units
+    return kT / (bc.k_B / bc.e)
 
 
 # @torch.jit.script

--- a/torch_sim/quantities.py
+++ b/torch_sim/quantities.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import torch
 
-from torch_sim.units import MetalUnits
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K
 
 
 if TYPE_CHECKING:
@@ -73,7 +73,7 @@ def calc_temperature(
     velocities: torch.Tensor | None = None,
     system_idx: torch.Tensor | None = None,
     dof_per_system: torch.Tensor | None = None,
-    units: MetalUnits = MetalUnits.temperature,
+    units: float = BOLTZMANN_CONSTANT_EV_PER_K,
 ) -> torch.Tensor:
     """Calculate temperature from momenta/velocities and masses.
 

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -11,6 +11,7 @@ import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 from itertools import chain
+from math import sqrt
 from typing import Any
 
 import torch
@@ -25,7 +26,7 @@ from torch_sim.optimizers import OPTIM_REGISTRY, FireState, Optimizer, OptimStat
 from torch_sim.state import _CANONICAL_MODEL_KEYS, SimState
 from torch_sim.trajectory import TrajectoryReporter
 from torch_sim.typing import StateLike
-from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
+from torch_sim.units import bc, uc
 
 
 logger = logging.getLogger(__name__)
@@ -301,8 +302,12 @@ def integrate[T: SimState](  # noqa: C901
     )
     dtype, device = initial_state.dtype, initial_state.device
     kTs = _normalize_temperature_tensor(temperature, n_steps, initial_state)
-    kTs = kTs * BOLTZMANN_CONSTANT_EV_PER_K
-    dt = torch.as_tensor(timestep * PS_TO_INTERNAL_TIME, dtype=dtype, device=device)
+    kTs = kTs * (bc.k_B / bc.e)
+    dt = torch.as_tensor(
+        timestep * (sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s),
+        dtype=dtype,
+        device=device,
+    )
 
     # Handle both string names and direct function tuples
     if isinstance(integrator, Integrator):

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -25,11 +25,7 @@ from torch_sim.optimizers import OPTIM_REGISTRY, FireState, Optimizer, OptimStat
 from torch_sim.state import _CANONICAL_MODEL_KEYS, SimState
 from torch_sim.trajectory import TrajectoryReporter
 from torch_sim.typing import StateLike
-from torch_sim.units import (
-    BAR_TO_EV_PER_ANGSTROM3,
-    BOLTZMANN_CONSTANT_EV_PER_K,
-    PS_TO_INTERNAL_TIME,
-)
+from torch_sim.units import BOLTZMANN_CONSTANT_EV_PER_K, PS_TO_INTERNAL_TIME
 
 
 logger = logging.getLogger(__name__)
@@ -253,64 +249,7 @@ def _write_initial_state(
             trajectory_reporter.report(state, 0, model=model)
 
 
-_INTEGRATOR_INIT_KWARG_FACTORS = {
-    Integrator.nvt_nose_hoover: {"tau": PS_TO_INTERNAL_TIME},
-    Integrator.npt_langevin_anisotropic: {
-        "b_tau": PS_TO_INTERNAL_TIME,
-        "alpha": 1 / PS_TO_INTERNAL_TIME,
-        "cell_alpha": 1 / PS_TO_INTERNAL_TIME,
-    },
-    Integrator.npt_langevin_isotropic: {
-        "b_tau": PS_TO_INTERNAL_TIME,
-        "alpha": 1 / PS_TO_INTERNAL_TIME,
-        "cell_alpha": 1 / PS_TO_INTERNAL_TIME,
-    },
-    Integrator.npt_nose_hoover_isotropic: {
-        "t_tau": PS_TO_INTERNAL_TIME,
-        "b_tau": PS_TO_INTERNAL_TIME,
-    },
-    Integrator.npt_crescale_isotropic: {
-        "tau_p": PS_TO_INTERNAL_TIME,
-        "isothermal_compressibility": 1 / BAR_TO_EV_PER_ANGSTROM3,
-    },
-    Integrator.npt_crescale_triclinic: {
-        "tau_p": PS_TO_INTERNAL_TIME,
-        "isothermal_compressibility": 1 / BAR_TO_EV_PER_ANGSTROM3,
-    },
-}
-
-_INTEGRATOR_STEP_KWARG_FACTORS = {
-    Integrator.nvt_vrescale: {"tau": PS_TO_INTERNAL_TIME},
-    Integrator.nvt_langevin: {"gamma": 1 / PS_TO_INTERNAL_TIME},
-    Integrator.npt_langevin_anisotropic: {"external_pressure": BAR_TO_EV_PER_ANGSTROM3},
-    Integrator.npt_langevin_isotropic: {"external_pressure": BAR_TO_EV_PER_ANGSTROM3},
-    Integrator.npt_nose_hoover_isotropic: {"external_pressure": BAR_TO_EV_PER_ANGSTROM3},
-    Integrator.npt_crescale_isotropic: {
-        "external_pressure": BAR_TO_EV_PER_ANGSTROM3,
-        "tau": PS_TO_INTERNAL_TIME,
-    },
-    Integrator.npt_crescale_triclinic: {
-        "external_pressure": BAR_TO_EV_PER_ANGSTROM3,
-        "tau": PS_TO_INTERNAL_TIME,
-    },
-}
-
-
-def _convert_integrator_kwargs(
-    integrator: Integrator,
-    init_kwargs: dict[str, Any],
-    step_kwargs: dict[str, Any],
-) -> None:
-    """Convert public integrator kwargs to TorchSim's internal units in place."""
-    for key, factor in _INTEGRATOR_INIT_KWARG_FACTORS.get(integrator, {}).items():
-        if init_kwargs.get(key) is not None:
-            init_kwargs[key] = init_kwargs[key] * factor
-    for key, factor in _INTEGRATOR_STEP_KWARG_FACTORS.get(integrator, {}).items():
-        if step_kwargs.get(key) is not None:
-            step_kwargs[key] = step_kwargs[key] * factor
-
-
-def integrate[T: SimState](  # noqa: C901, PLR0915
+def integrate[T: SimState](  # noqa: C901
     system: StateLike,
     model: ModelInterface,
     *,
@@ -333,26 +272,22 @@ def integrate[T: SimState](  # noqa: C901, PLR0915
             (init_func, step_func) functions.
         n_steps (int): Number of integration steps. If resuming from a trajectory, this
             is the  number of additional steps to run.
-        temperature (float | ArrayLike): Temperature in K, or an array of temperatures
-            for each step or system:
+        temperature (float | ArrayLike): Temperature or array of temperatures for each
+            step or system:
             Float: used for all steps and systems
             1D array of length n_steps: used for each step
             1D array of length n_systems: used for each system
             2D array of shape (n_steps, n_systems): used for each step and system.
-        timestep (float): Integration time step in ps.
+        timestep (float): Integration time step
         trajectory_reporter (TrajectoryReporter | dict | None): Optional reporter for
             tracking trajectory. If a dict, will be passed to the TrajectoryReporter
             constructor.
         autobatcher (BinningAutoBatcher | bool): Optional autobatcher to use
         pbar (bool | dict[str, Any], optional): Show a progress bar. If a dict is given,
             it's passed to `tqdm` as kwargs.
-        init_kwargs (dict[str, Any], optional): Additional keyword arguments for the
-            integrator init function. Registered integrators accept relaxation times
-            in ps, rates in ps^-1, and compressibility in bar^-1.
-        **integrator_kwargs: Additional keyword arguments for the integrator step
-            function. Registered integrators accept relaxation times in ps, rates in
-            ps^-1, and external pressure in bar. Custom integrator tuples receive
-            keyword arguments unchanged.
+        init_kwargs (dict[str, Any], optional): Additional keyword arguments for
+            integrator init function.
+        **integrator_kwargs: Additional keyword arguments for integrator init function
 
     Returns:
         T: Final state after integration
@@ -383,9 +318,6 @@ def integrate[T: SimState](  # noqa: C901, PLR0915
             f"integrator must be key from Integrator or a tuple of "
             f"(init_func, step_func), got {type(integrator)}"
         )
-    init_kwargs = dict(init_kwargs or {})
-    if isinstance(integrator, Integrator):
-        _convert_integrator_kwargs(integrator, init_kwargs, integrator_kwargs)
     # batch_iterator will be a list if autobatcher is False
     batch_iterator = _configure_batches_iterator(
         initial_state, model, autobatcher=autobatcher
@@ -417,7 +349,9 @@ def integrate[T: SimState](  # noqa: C901, PLR0915
         batch_kT = (
             kTs[:, system_indices] if (system_indices and len(kTs.shape) == 2) else kTs
         )
-        state = init_func(state=state, model=model, kT=batch_kT[0], dt=dt, **init_kwargs)
+        state = init_func(
+            state=state, model=model, kT=batch_kT[0], dt=dt, **init_kwargs or {}
+        )
 
         # set up trajectory reporters
         if autobatcher and trajectory_reporter is not None and og_filenames is not None:

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -25,7 +25,11 @@ from torch_sim.optimizers import OPTIM_REGISTRY, FireState, Optimizer, OptimStat
 from torch_sim.state import _CANONICAL_MODEL_KEYS, SimState
 from torch_sim.trajectory import TrajectoryReporter
 from torch_sim.typing import StateLike
-from torch_sim.units import UnitSystem
+from torch_sim.units import (
+    BAR_TO_EV_PER_ANGSTROM3,
+    BOLTZMANN_CONSTANT_EV_PER_K,
+    PS_TO_INTERNAL_TIME,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -249,7 +253,64 @@ def _write_initial_state(
             trajectory_reporter.report(state, 0, model=model)
 
 
-def integrate[T: SimState](  # noqa: C901
+_INTEGRATOR_INIT_KWARG_FACTORS = {
+    Integrator.nvt_nose_hoover: {"tau": PS_TO_INTERNAL_TIME},
+    Integrator.npt_langevin_anisotropic: {
+        "b_tau": PS_TO_INTERNAL_TIME,
+        "alpha": 1 / PS_TO_INTERNAL_TIME,
+        "cell_alpha": 1 / PS_TO_INTERNAL_TIME,
+    },
+    Integrator.npt_langevin_isotropic: {
+        "b_tau": PS_TO_INTERNAL_TIME,
+        "alpha": 1 / PS_TO_INTERNAL_TIME,
+        "cell_alpha": 1 / PS_TO_INTERNAL_TIME,
+    },
+    Integrator.npt_nose_hoover_isotropic: {
+        "t_tau": PS_TO_INTERNAL_TIME,
+        "b_tau": PS_TO_INTERNAL_TIME,
+    },
+    Integrator.npt_crescale_isotropic: {
+        "tau_p": PS_TO_INTERNAL_TIME,
+        "isothermal_compressibility": 1 / BAR_TO_EV_PER_ANGSTROM3,
+    },
+    Integrator.npt_crescale_triclinic: {
+        "tau_p": PS_TO_INTERNAL_TIME,
+        "isothermal_compressibility": 1 / BAR_TO_EV_PER_ANGSTROM3,
+    },
+}
+
+_INTEGRATOR_STEP_KWARG_FACTORS = {
+    Integrator.nvt_vrescale: {"tau": PS_TO_INTERNAL_TIME},
+    Integrator.nvt_langevin: {"gamma": 1 / PS_TO_INTERNAL_TIME},
+    Integrator.npt_langevin_anisotropic: {"external_pressure": BAR_TO_EV_PER_ANGSTROM3},
+    Integrator.npt_langevin_isotropic: {"external_pressure": BAR_TO_EV_PER_ANGSTROM3},
+    Integrator.npt_nose_hoover_isotropic: {"external_pressure": BAR_TO_EV_PER_ANGSTROM3},
+    Integrator.npt_crescale_isotropic: {
+        "external_pressure": BAR_TO_EV_PER_ANGSTROM3,
+        "tau": PS_TO_INTERNAL_TIME,
+    },
+    Integrator.npt_crescale_triclinic: {
+        "external_pressure": BAR_TO_EV_PER_ANGSTROM3,
+        "tau": PS_TO_INTERNAL_TIME,
+    },
+}
+
+
+def _convert_integrator_kwargs(
+    integrator: Integrator,
+    init_kwargs: dict[str, Any],
+    step_kwargs: dict[str, Any],
+) -> None:
+    """Convert public integrator kwargs to TorchSim's internal units in place."""
+    for key, factor in _INTEGRATOR_INIT_KWARG_FACTORS.get(integrator, {}).items():
+        if init_kwargs.get(key) is not None:
+            init_kwargs[key] = init_kwargs[key] * factor
+    for key, factor in _INTEGRATOR_STEP_KWARG_FACTORS.get(integrator, {}).items():
+        if step_kwargs.get(key) is not None:
+            step_kwargs[key] = step_kwargs[key] * factor
+
+
+def integrate[T: SimState](  # noqa: C901, PLR0915
     system: StateLike,
     model: ModelInterface,
     *,
@@ -272,28 +333,30 @@ def integrate[T: SimState](  # noqa: C901
             (init_func, step_func) functions.
         n_steps (int): Number of integration steps. If resuming from a trajectory, this
             is the  number of additional steps to run.
-        temperature (float | ArrayLike): Temperature or array of temperatures for each
-            step or system:
+        temperature (float | ArrayLike): Temperature in K, or an array of temperatures
+            for each step or system:
             Float: used for all steps and systems
             1D array of length n_steps: used for each step
             1D array of length n_systems: used for each system
             2D array of shape (n_steps, n_systems): used for each step and system.
-        timestep (float): Integration time step
+        timestep (float): Integration time step in ps.
         trajectory_reporter (TrajectoryReporter | dict | None): Optional reporter for
             tracking trajectory. If a dict, will be passed to the TrajectoryReporter
             constructor.
         autobatcher (BinningAutoBatcher | bool): Optional autobatcher to use
         pbar (bool | dict[str, Any], optional): Show a progress bar. If a dict is given,
             it's passed to `tqdm` as kwargs.
-        init_kwargs (dict[str, Any], optional): Additional keyword arguments for
-            integrator init function.
-        **integrator_kwargs: Additional keyword arguments for integrator init function
+        init_kwargs (dict[str, Any], optional): Additional keyword arguments for the
+            integrator init function. Registered integrators accept relaxation times
+            in ps, rates in ps^-1, and compressibility in bar^-1.
+        **integrator_kwargs: Additional keyword arguments for the integrator step
+            function. Registered integrators accept relaxation times in ps, rates in
+            ps^-1, and external pressure in bar. Custom integrator tuples receive
+            keyword arguments unchanged.
 
     Returns:
         T: Final state after integration
     """
-    unit_system = UnitSystem.metal
-
     initial_state: SimState = ts.initialize_state(system, model.device, model.dtype)
     logger.info(
         "integrate: n_systems=%d, n_steps=%d, integrator=%s",
@@ -303,8 +366,8 @@ def integrate[T: SimState](  # noqa: C901
     )
     dtype, device = initial_state.dtype, initial_state.device
     kTs = _normalize_temperature_tensor(temperature, n_steps, initial_state)
-    kTs = kTs * unit_system.temperature
-    dt = torch.as_tensor(timestep * unit_system.time, dtype=dtype, device=device)
+    kTs = kTs * BOLTZMANN_CONSTANT_EV_PER_K
+    dt = torch.as_tensor(timestep * PS_TO_INTERNAL_TIME, dtype=dtype, device=device)
 
     # Handle both string names and direct function tuples
     if isinstance(integrator, Integrator):
@@ -320,6 +383,9 @@ def integrate[T: SimState](  # noqa: C901
             f"integrator must be key from Integrator or a tuple of "
             f"(init_func, step_func), got {type(integrator)}"
         )
+    init_kwargs = dict(init_kwargs or {})
+    if isinstance(integrator, Integrator):
+        _convert_integrator_kwargs(integrator, init_kwargs, integrator_kwargs)
     # batch_iterator will be a list if autobatcher is False
     batch_iterator = _configure_batches_iterator(
         initial_state, model, autobatcher=autobatcher
@@ -351,9 +417,7 @@ def integrate[T: SimState](  # noqa: C901
         batch_kT = (
             kTs[:, system_indices] if (system_indices and len(kTs.shape) == 2) else kTs
         )
-        state = init_func(
-            state=state, model=model, kT=batch_kT[0], dt=dt, **init_kwargs or {}
-        )
+        state = init_func(state=state, model=model, kT=batch_kT[0], dt=dt, **init_kwargs)
 
         # set up trajectory reporters
         if autobatcher and trajectory_reporter is not None and og_filenames is not None:

--- a/torch_sim/units.py
+++ b/torch_sim/units.py
@@ -2,7 +2,7 @@
 """Physical constants and unit conversion factors used by TorchSim."""
 
 from enum import Enum
-from math import pi, sqrt
+from math import pi
 from typing import Self
 
 
@@ -60,10 +60,3 @@ class UnitConversion(float, Enum):
 
 
 uc = UnitConversion
-
-# TorchSim state uses Angstrom, eV, and atomic mass units. These are the only
-# non-trivial factors needed to convert the public MD API (K, ps, bar) to the
-# coherent internal values required by the low-level integrators.
-BOLTZMANN_CONSTANT_EV_PER_K = bc.k_B / bc.e
-PS_TO_INTERNAL_TIME = sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s
-BAR_TO_EV_PER_ANGSTROM3 = uc.bar_to_pa * uc.Ang3_to_met3 / bc.e

--- a/torch_sim/units.py
+++ b/torch_sim/units.py
@@ -1,9 +1,5 @@
-# ruff: noqa: N815, PIE796
-"""Unit systems and conversions.
-
-Defines a units system and returns a dictionary of conversion factors.
-Units are defined similar to https://docs.lammps.org/units.html.
-"""
+# ruff: noqa: N815
+"""Physical constants and unit conversion factors used by TorchSim."""
 
 from enum import Enum
 from math import pi, sqrt
@@ -65,62 +61,9 @@ class UnitConversion(float, Enum):
 
 uc = UnitConversion
 
-
-class MetalUnits(float, Enum):
-    """Metal unit system using Angstroms, eV, amu, and proton charge."""
-
-    def __new__(cls, value: float) -> Self:
-        """Create new MetalUnits enum value."""
-        return float.__new__(cls, value)
-
-    # Base units
-    mass = 1.0  # Default mass in amu
-    distance = 1.0  # Default distance in Angstrom
-    energy = 1.0  # Default energy in eV
-    charge = 1.0  # Default charge in proton charge
-
-    # Derived units
-    time = sqrt(energy * bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s  # picoseconds
-    velocity = distance / time  # Ang/ps
-    force = energy / distance  # eV/Ang
-    torque = energy  # eV
-    temperature = bc.k_B / bc.e  # Boltzmann in eV/K
-    pressure = uc.bar_to_pa * (energy * uc.Ang3_to_met3 / bc.e)  # bar
-    electric_field = charge * distance  # e*Ang
-
-
-class RealUnits(float, Enum):
-    """Real unit system using Angstroms, kcal/mol, and proton charge."""
-
-    def __new__(cls, value: float) -> Self:
-        """Create new RealUnits enum value."""
-        return float.__new__(cls, value)
-
-    # Base units
-    mass = 1.0  # Default mass in grams/mol
-    distance = 1.0  # Default distance in Angstrom
-    energy = 1.0  # Default energy in kcal/mol
-    charge = 1.0  # Default charge in proton charge
-
-    # Derived units
-    time = (
-        sqrt(
-            energy / (bc.amu * uc.Ang2_to_met2 * bc.n_av / (uc.cal_to_J * uc.kcal_to_cal))
-        )
-        * uc.fs_to_s
-    )  # femtoseconds
-    velocity = distance / time  # Ang/fs
-    force = energy / distance  # kcal/mol/Ang
-    torque = energy  # kcal/mol
-    temperature = bc.k_B * bc.n_av / uc.cal_to_J / uc.kcal_to_cal  # kcal/mol K
-    pressure = (
-        uc.Ang3_to_met3 * (bc.n_av / (uc.cal_to_J * uc.kcal_to_cal)) * uc.bar_to_pa
-    )  # bar
-    electric_field = charge * distance  # e*Ang
-
-
-class UnitSystem:
-    """Container class for unit systems."""
-
-    metal = MetalUnits
-    real = RealUnits
+# TorchSim state uses Angstrom, eV, and atomic mass units. These are the only
+# non-trivial factors needed to convert the public MD API (K, ps, bar) to the
+# coherent internal values required by the low-level integrators.
+BOLTZMANN_CONSTANT_EV_PER_K = bc.k_B / bc.e
+PS_TO_INTERNAL_TIME = sqrt(bc.e / (bc.amu * uc.Ang2_to_met2)) * uc.ps_to_s
+BAR_TO_EV_PER_ANGSTROM3 = uc.bar_to_pa * uc.Ang3_to_met3 / bc.e


### PR DESCRIPTION
## Summary

As Rhys pointed out, it's not 100% necessary and the entire concept was originally ported over from ASE. Having values passed in two kinds of units (metal vs non-metal) was giving us issues because some interfaces had inconsistent units https://github.com/TorchSim/torch-sim/issues/579

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
