### PR TITLE
Free cached memory inside the batch-size probe, not after estimation

### DIFF
--- a/tests/test_autobatching.py
+++ b/tests/test_autobatching.py
@@ -554,6 +554,45 @@ def test_determine_max_batch_size_recognises_oom_variants(
     assert max_size >= 1
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.parametrize("probe_ooms", [True, False])
+def test_determine_max_batch_size_releases_cached_memory(
+    *,
+    si_sim_state: ts.SimState,
+    lj_model: LennardJonesModel,
+    monkeypatch: pytest.MonkeyPatch,
+    probe_ooms: bool,
+) -> None:
+    """The probe must hand the device back on every exit path.
+
+    Regression test: probing deliberately grows batches until the GPU runs out
+    of memory. If PyTorch's caching allocator keeps holding that memory after
+    the probe returns, a separate allocator - such as the Warp/cudaMallocAsync
+    pool behind the alchemiops neighbor lists - can fail to allocate even a few
+    bytes on the very next call.
+    """
+
+    def mock_measure(*_args: Any, **_kwargs: Any) -> float:
+        # Reserve a chunk and release it, so it lands in PyTorch's cache the
+        # way a real probe's activations do.
+        buffer = torch.empty(256 * 1024**2, dtype=torch.uint8, device="cuda")
+        del buffer
+        if probe_ooms:
+            raise RuntimeError("CUDA out of memory")
+        return 0.1
+
+    monkeypatch.setattr(
+        "torch_sim.autobatching.measure_model_memory_forward", mock_measure
+    )
+
+    torch.cuda.empty_cache()
+    baseline = torch.cuda.memory_reserved()
+
+    determine_max_batch_size(si_sim_state, lj_model, max_atoms=10_000)
+
+    assert torch.cuda.memory_reserved() <= baseline
+
+
 def test_determine_max_batch_size_reraises_non_oom_error(
     si_sim_state: ts.SimState,
     lj_model: LennardJonesModel,

--- a/torch_sim/autobatching.py
+++ b/torch_sim/autobatching.py
@@ -237,6 +237,11 @@ def determine_max_batch_size(
     Notes:
         The function returns a batch size slightly smaller than the actual maximum
         (with a safety margin) to avoid operating too close to memory limits.
+
+        On CUDA devices the caching allocator is released before returning, so that
+        separately-allocating backends - such as the Warp/cudaMallocAsync pool behind
+        the alchemiops neighbor lists - are not starved by memory the probe left
+        cached.
     """
     # Convert oom_error_message to list if it's a string
     if isinstance(oom_error_message, str):
@@ -249,29 +254,40 @@ def determine_max_batch_size(
     ) * state.n_atoms <= max_atoms:
         sizes.append(next_size)
 
-    for sys_idx in range(len(sizes)):
-        n_systems = sizes[sys_idx]
-        concat_state = ts.concatenate_states([state] * n_systems)
+    try:
+        for sys_idx in range(len(sizes)):
+            n_systems = sizes[sys_idx]
+            concat_state = ts.concatenate_states([state] * n_systems)
 
-        try:
-            measure_model_memory_forward(concat_state, model)
-        except Exception as exc:
-            exc_str = str(exc)
-            # Check if any of the OOM error messages match
-            if any(msg in exc_str for msg in oom_error_message):
-                safe_size = sizes[max(0, sys_idx - 2)]
-                logger.debug(
-                    "OOM at %d systems (%d atoms), returning safe batch size %d",
-                    n_systems,
-                    concat_state.n_atoms,
-                    safe_size,
-                )
-                return safe_size
+            try:
+                measure_model_memory_forward(concat_state, model)
+            except Exception as exc:
+                exc_str = str(exc)
+                # Check if any of the OOM error messages match
+                if any(msg in exc_str for msg in oom_error_message):
+                    safe_size = sizes[max(0, sys_idx - 2)]
+                    logger.debug(
+                        "OOM at %d systems (%d atoms), returning safe batch size %d",
+                        n_systems,
+                        concat_state.n_atoms,
+                        safe_size,
+                    )
+                    return safe_size
 
-            # Not an OOM error - re-raise
-            raise
+                # Not an OOM error - re-raise
+                raise
 
-    return sizes[-1]
+        return sizes[-1]
+    finally:
+        # The probing above deliberately grows batches until an OOM, which
+        # leaves PyTorch's caching allocator holding most of the device memory.
+        # Release it on every exit path, including the OOM return above: a
+        # separate allocator - such as the Warp/cudaMallocAsync pool behind the
+        # alchemiops neighbor lists - draws from what PyTorch is not holding, so
+        # it can otherwise fail to allocate even a few bytes on the next call.
+        if torch.cuda.is_available():  # pragma: no cover
+            torch.cuda.synchronize()
+            torch.cuda.empty_cache()
 
 
 def _n_edges_scalers(state: SimState, cutoff: float) -> list[float]:
@@ -445,17 +461,10 @@ def estimate_max_memory_scaler(
         f"and {max_state.n_systems} batches, and smallest system has "
         f"{min_state.n_atoms} atoms and {min_state.n_systems} batches.",
     )
+    # determine_max_batch_size releases the caching allocator on its way out, so
+    # the device is already handed back before the real optimization run starts.
     min_state_max_batches = determine_max_batch_size(min_state, model, **kwargs)
     max_state_max_batches = determine_max_batch_size(max_state, model, **kwargs)
-
-    # The probing above deliberately grows batches until an OOM, which leaves
-    # PyTorch's caching allocator holding most of the device memory. Release it
-    # so the real optimization run - and in particular any separate allocator
-    # such as the Warp/cudaMallocAsync pool used by ORB's neighbor lists - is
-    # not starved on the first real forward pass.
-    if torch.cuda.is_available():  # pragma: no cover
-        torch.cuda.synchronize()
-        torch.cuda.empty_cache()
 
     return min(
         min_state_max_batches * min_metric.item(),


### PR DESCRIPTION
`determine_max_batch_size` deliberately grows batches until the GPU runs out of memory, but left PyTorch's caching allocator holding the device on the way out. #589 added an `empty_cache()` for this, at the end of `estimate_max_memory_scaler` — but `InFlightAutoBatcher._get_first_batch` calls `_get_next_states()` *between* the first probe and `estimate_max_memory_scaler`, so the starved allocation happens one step before the guard:

1. `determine_max_batch_size(first_state)` — probe, leaves the card full
2. `_get_next_states()` — neighbor-list calls ← **fails here**
3. `estimate_max_memory_scaler()` — two more probes, then #589's `empty_cache()`
4. `_get_next_states()` again — protected
5. the optimization run — protected

This is only reachable with `memory_scales_with="n_edges"` and alchemiops installed. `n_atoms` and the default `n_atoms_x_density` compute their scalers with pure tensor arithmetic and never build a neighbor list, so on the default path `_get_next_states()` makes no Warp allocations at all.

Move the release into `determine_max_batch_size` itself, in a `finally` covering all three exits: normal completion, the early return on a caught OOM, and the re-raise on a non-OOM error. The OOM return is the path that matters in practice. Deferring to the outer `finally` matters: by then the `except` clause's implicit `del exc` has dropped the traceback frames and the activations they pin, so `empty_cache()` can actually reclaim them.

Measured with SevenNet `7net-0` over 878 molecules on a 24 GB card, `memory_scales_with="n_edges"`. The ladder is seeded from a 16-atom molecule and capped at the set's 22,260 atoms, so it tops out at 1071 replicas (17,136 atoms), which OOMs:

| after the probe returns | before | after |
| --- | --- | --- |
| reserved | 21.27 GB | 0.05 GB |
| free on device | 0.03 GB | 21.24 GB |
| next neighbor-list call | `RuntimeError: Failed to allocate 72 bytes on device 'cuda:0'` | OK |
| returned batch size | 350 | 350 |

The estimate is unchanged, and can't change: `measure_model_memory_forward` already calls `empty_cache()` at the top of every rung, so each measurement already begins from a cleared cache, and the value it returns is `max_memory_allocated()` — a high-water mark of *allocated* bytes, which `empty_cache()` cannot move.

The guard in `estimate_max_memory_scaler` is now redundant and is removed, so the invariant lives with the function that breaks it.

## Summary

* Release PyTorch's caching allocator inside `determine_max_batch_size` via `finally`, so every exit path hands the device back — fixes `Failed to allocate N bytes` from Warp-backed neighbor lists in `_get_next_states()` when `memory_scales_with="n_edges"`
* Remove the now-redundant `empty_cache()` from `estimate_max_memory_scaler`, whose probes now clean up after themselves
* Add a parametrized regression test covering both the OOM and clean-completion exits
