### PR TITLE
alchemiops.py: Flag as unavailable on non-NVIDIA torch builds

### DIFF
--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -528,6 +528,27 @@ def test_fallback_when_alchemiops_unavailable(monkeypatch: pytest.MonkeyPatch) -
     assert mapping2.shape[1] > 0
 
 
+def test_alchemiops_import_guard_non_nvidia_builds(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """nvalchemiops is flagged unavailable on non-NVIDIA GPU torch builds.
+
+    On ROCm builds ``torch.version.cuda`` is ``None`` even though a GPU is
+    present, and on CPU-only builds ``torch.cuda.is_available()`` is ``False``.
+    alcheimops works on CPUs, and on NVIDIA GPUs, but not on non-NVIDIA GPUs.
+    """
+    from torch_sim.neighbors.alchemiops import _import_nvalchemiops_batch_neighbors
+
+    # Simulate a ROCm build: HIP is available, but there is no CUDA runtime.
+    monkeypatch.setattr(torch.version, "cuda", None)
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    assert _import_nvalchemiops_batch_neighbors() is None
+
+    # Simulate a CPU build.
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    assert _import_nvalchemiops_batch_neighbors() is not None
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="GPU not available for testing")
 def test_torchsim_nl_gpu() -> None:
     """Test that torchsim_nl works on GPU (CUDA/ROCm)."""

--- a/torch_sim/neighbors/alchemiops.py
+++ b/torch_sim/neighbors/alchemiops.py
@@ -17,6 +17,13 @@ _batch_cell_list: object | None = None
 
 def _import_nvalchemiops_batch_neighbors() -> tuple[object, object] | None:
     """Return ``(batch_cell_list, batch_naive_neighbor_list)`` if importable."""
+    # nvalchemiops is NVIDIA-CUDA-only (built on warp) for GPUs
+    # It does not work on non-NVIDIA builds.  In particular, on ROCm
+    # builds, nvalchemiops will fail during runtime, even though
+    # Python bindings are imported without issues.
+    if torch.version.cuda is None\
+       and torch.cuda.is_available():  # On ROCm, == True
+        return None
     try:
         from nvalchemiops.torch.neighbors import batch_cell_list as bcl
         from nvalchemiops.torch.neighbors import batch_naive_neighbor_list as bnl


### PR DESCRIPTION
## Summary

On ROCm builds, nvalchemiops correctly imports but does not work during runtime, yielding

  File "<...>/lib/python3.12/site-packages/torch_sim/neighbors/__init__.py", line 86, in torchsim_nl
    return alchemiops_nl_n2(
           ^^^^^^^^^^^^^^^^^
  File "<...>/lib/python3.12/site-packages/torch_sim/neighbors/alchemiops.py", line 62, in alchemiops_nl_n2
    res = _batch_naive_neighbor_list(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<...>/lib/python3.12/site-packages/nvalchemiops/torch/neighbors/batch_naive.py", line 1513, in batch_naive_neighbor_list
    compute_naive_num_shifts(cell, cutoff, pbc)
  File "<...>/lib/python3.12/site-packages/nvalchemiops/torch/neighbors/neighbor_utils.py", line 326, in compute_naive_num_shifts
    wp_device = wp.device_from_torch(device)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<...>/lib/python3.12/site-packages/warp/_src/torch.py", line 39, in device_from_torch
    return warp._src.context.runtime.cuda_devices[torch_device.index]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
IndexError: list index out of range

## Checklist

Before a pull request can be merged, the following items must be checked:

* [X] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google), but not in `_import_nvalchemiops_batch_neighbors`, which I did not touch.
* [X] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code. (no new failures)
* [X] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->
